### PR TITLE
add "SQLite." prefix in Table, Expression

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		92D059CD2C9E057A000460F7 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 92D059CC2C9E057A000460F7 /* SQLite */; };
+		92D059CF2C9E08C7000460F7 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 92D059CA2C9E044E000460F7 /* libsqlite3.tbd */; };
 		A3363EE32C9323A5004696C7 /* CategoryEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EE22C9323A5004696C7 /* CategoryEditView.swift */; };
 		A3363EE52C9323D2004696C7 /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EE42C9323D2004696C7 /* CategoryDetailView.swift */; };
 		A3363EE72C93249D004696C7 /* CategoryAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EE62C93249D004696C7 /* CategoryAddView.swift */; };
@@ -30,13 +32,10 @@
 		A39B1B342C99A0A8003E5562 /* CurrencyDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39B1B332C99A0A8003E5562 /* CurrencyDetailView.swift */; };
 		A39B1B362C99A0C2003E5562 /* CurrencyEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39B1B352C99A0C2003E5562 /* CurrencyEditView.swift */; };
 		A39B1B382C99A0D8003E5562 /* CurrencyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39B1B372C99A0D8003E5562 /* CurrencyListView.swift */; };
-		A3B374C52C96A23E00943FDB /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = A3B374C42C96A23E00943FDB /* SQLite */; };
-		A3B374C72C96A27800943FDB /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = A3B374C62C96A27800943FDB /* SQLite */; };
 		A3C1422B2C89751500D3CEC0 /* MMEXApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C1422A2C89751500D3CEC0 /* MMEXApp.swift */; };
 		A3C1422D2C89751500D3CEC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C1422C2C89751500D3CEC0 /* ContentView.swift */; };
 		A3C1422F2C89751600D3CEC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A3C1422E2C89751600D3CEC0 /* Assets.xcassets */; };
 		A3C142322C89751600D3CEC0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A3C142312C89751600D3CEC0 /* Preview Assets.xcassets */; };
-		A3C1423A2C89754C00D3CEC0 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = A3C142392C89754C00D3CEC0 /* SQLite */; };
 		A3C1423E2C89760600D3CEC0 /* AccountListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C1423D2C89760600D3CEC0 /* AccountListView.swift */; };
 		A3C142442C89C8FA00D3CEC0 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C142432C89C8FA00D3CEC0 /* Account.swift */; };
 		A3C142472C89CB4200D3CEC0 /* AccountDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C142462C89CB4200D3CEC0 /* AccountDetailView.swift */; };
@@ -67,6 +66,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		92D059CA2C9E044E000460F7 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		92D059CB2C9E046C000460F7 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
 		A3363EE22C9323A5004696C7 /* CategoryEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEditView.swift; sourceTree = "<group>"; };
 		A3363EE42C9323D2004696C7 /* CategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailView.swift; sourceTree = "<group>"; };
 		A3363EE62C93249D004696C7 /* CategoryAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryAddView.swift; sourceTree = "<group>"; };
@@ -130,15 +131,23 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A3B374C72C96A27800943FDB /* SQLite in Frameworks */,
-				A3B374C52C96A23E00943FDB /* SQLite in Frameworks */,
-				A3C1423A2C89754C00D3CEC0 /* SQLite in Frameworks */,
+				92D059CF2C9E08C7000460F7 /* libsqlite3.tbd in Frameworks */,
+				92D059CD2C9E057A000460F7 /* SQLite in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		92D059C92C9E044E000460F7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				92D059CB2C9E046C000460F7 /* libsqlite3.0.tbd */,
+				92D059CA2C9E044E000460F7 /* libsqlite3.tbd */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A3462F672C948C8400F79145 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -244,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				A3C142292C89751500D3CEC0 /* MMEX */,
+				92D059C92C9E044E000460F7 /* Frameworks */,
 				A3C142282C89751500D3CEC0 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -330,9 +340,7 @@
 			);
 			name = MMEX;
 			packageProductDependencies = (
-				A3C142392C89754C00D3CEC0 /* SQLite */,
-				A3B374C42C96A23E00943FDB /* SQLite */,
-				A3B374C62C96A27800943FDB /* SQLite */,
+				92D059CC2C9E057A000460F7 /* SQLite */,
 			);
 			productName = MMEX;
 			productReference = A3C142272C89751500D3CEC0 /* MMEX.app */;
@@ -346,7 +354,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1540;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					A3C142262C89751500D3CEC0 = {
 						CreatedOnToolsVersion = 15.4;
@@ -455,6 +463,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -518,6 +527,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -670,16 +680,9 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		A3B374C42C96A23E00943FDB /* SQLite */ = {
+		92D059CC2C9E057A000460F7 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = SQLite;
-		};
-		A3B374C62C96A27800943FDB /* SQLite */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SQLite;
-		};
-		A3C142392C89754C00D3CEC0 /* SQLite */ = {
-			isa = XCSwiftPackageProductDependency;
+			package = A3C142382C89754C00D3CEC0 /* XCLocalSwiftPackageReference "../SQLite.swift" */;
 			productName = SQLite;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/MMEX/Models/Infotable.swift
+++ b/MMEX/Models/Infotable.swift
@@ -56,9 +56,9 @@ extension Infotable {
 extension Infotable {
     static var empty: Infotable { Infotable(id: 0, name: "", value: "") }
 
-    static let table = Table("INFOTABLE_V1")
+    static let table = SQLite.Table("INFOTABLE_V1")
 
-    static let infoID = Expression<Int64>("INFOID")
-    static let infoName = Expression<String>("INFONAME")
-    static let infoValue = Expression<String>("INFOVALUE")
+    static let infoID    = SQLite.Expression<Int64>("INFOID")
+    static let infoName  = SQLite.Expression<String>("INFONAME")
+    static let infoValue = SQLite.Expression<String>("INFOVALUE")
 }

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -18,37 +18,37 @@ class AccountRepository {
 
 extension AccountRepository {
     // table query
-    static let table = Table("ACCOUNTLIST_V1")
+    static let table = SQLite.Table("ACCOUNTLIST_V1")
 
     // table columns
-    static let col_id              = Expression<Int64>("ACCOUNTID")
-    static let col_name            = Expression<String>("ACCOUNTNAME")
-    static let col_type            = Expression<String>("ACCOUNTTYPE")
-    static let col_num             = Expression<String?>("ACCOUNTNUM")
-    static let col_status          = Expression<String>("STATUS")
-    static let col_notes           = Expression<String?>("NOTES")
-    static let col_heldAt          = Expression<String?>("HELDAT")
-    static let col_website         = Expression<String?>("WEBSITE")
-    static let col_contactInfo     = Expression<String?>("CONTACTINFO")
-    static let col_accessInfo      = Expression<String?>("ACCESSINFO")
-    static let col_initialDate     = Expression<String?>("INITIALDATE")
-    static let col_initialBal      = Expression<Double?>("INITIALBAL")
-    static let col_favoriteAcct    = Expression<String>("FAVORITEACCT")
-    static let col_currencyId      = Expression<Int64>("CURRENCYID")
-    static let col_statementLocked = Expression<Int?>("STATEMENTLOCKED")
-    static let col_statementDate   = Expression<String?>("STATEMENTDATE")
-    static let col_minimumBalance  = Expression<Double?>("MINIMUMBALANCE")
-    static let col_creditLimit     = Expression<Double?>("CREDITLIMIT")
-    static let col_interestRate    = Expression<Double?>("INTERESTRATE")
-    static let col_paymentDueDate  = Expression<String?>("PAYMENTDUEDATE")
-    static let col_minimumPayment  = Expression<Double?>("MINIMUMPAYMENT")
+    static let col_id              = SQLite.Expression<Int64>("ACCOUNTID")
+    static let col_name            = SQLite.Expression<String>("ACCOUNTNAME")
+    static let col_type            = SQLite.Expression<String>("ACCOUNTTYPE")
+    static let col_num             = SQLite.Expression<String?>("ACCOUNTNUM")
+    static let col_status          = SQLite.Expression<String>("STATUS")
+    static let col_notes           = SQLite.Expression<String?>("NOTES")
+    static let col_heldAt          = SQLite.Expression<String?>("HELDAT")
+    static let col_website         = SQLite.Expression<String?>("WEBSITE")
+    static let col_contactInfo     = SQLite.Expression<String?>("CONTACTINFO")
+    static let col_accessInfo      = SQLite.Expression<String?>("ACCESSINFO")
+    static let col_initialDate     = SQLite.Expression<String?>("INITIALDATE")
+    static let col_initialBal      = SQLite.Expression<Double?>("INITIALBAL")
+    static let col_favoriteAcct    = SQLite.Expression<String>("FAVORITEACCT")
+    static let col_currencyId      = SQLite.Expression<Int64>("CURRENCYID")
+    static let col_statementLocked = SQLite.Expression<Int?>("STATEMENTLOCKED")
+    static let col_statementDate   = SQLite.Expression<String?>("STATEMENTDATE")
+    static let col_minimumBalance  = SQLite.Expression<Double?>("MINIMUMBALANCE")
+    static let col_creditLimit     = SQLite.Expression<Double?>("CREDITLIMIT")
+    static let col_interestRate    = SQLite.Expression<Double?>("INTERESTRATE")
+    static let col_paymentDueDate  = SQLite.Expression<String?>("PAYMENTDUEDATE")
+    static let col_minimumPayment  = SQLite.Expression<Double?>("MINIMUMPAYMENT")
 
     // cast NUMERIC to REAL
-    static let cast_initialBal     = cast(col_initialBal)     as Expression<Double?>
-    static let cast_minimumBalance = cast(col_minimumBalance) as Expression<Double?>
-    static let cast_creditLimit    = cast(col_creditLimit)    as Expression<Double?>
-    static let cast_interestRate   = cast(col_interestRate)   as Expression<Double?>
-    static let cast_minimumPayment = cast(col_minimumPayment) as Expression<Double?>
+    static let cast_initialBal     = cast(col_initialBal)     as SQLite.Expression<Double?>
+    static let cast_minimumBalance = cast(col_minimumBalance) as SQLite.Expression<Double?>
+    static let cast_creditLimit    = cast(col_creditLimit)    as SQLite.Expression<Double?>
+    static let cast_interestRate   = cast(col_interestRate)   as SQLite.Expression<Double?>
+    static let cast_minimumPayment = cast(col_minimumPayment) as SQLite.Expression<Double?>
 }
 
 extension AccountRepository {

--- a/MMEX/Repositories/CategoryRepository.swift
+++ b/MMEX/Repositories/CategoryRepository.swift
@@ -17,13 +17,13 @@ class CategoryRepository {
 
 extension CategoryRepository {
     // table query
-    static let table = Table("CATEGORY_V1")
+    static let table = SQLite.Table("CATEGORY_V1")
 
     // table columns
-    static let col_id       = Expression<Int64>("CATEGID")
-    static let col_name     = Expression<String>("CATEGNAME")
-    static let col_active   = Expression<Int?>("ACTIVE")
-    static let col_parentId = Expression<Int64?>("PARENTID")
+    static let col_id       = SQLite.Expression<Int64>("CATEGID")
+    static let col_name     = SQLite.Expression<String>("CATEGNAME")
+    static let col_active   = SQLite.Expression<Int?>("ACTIVE")
+    static let col_parentId = SQLite.Expression<Int64?>("PARENTID")
 }
 
 extension CategoryRepository {

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -18,24 +18,24 @@ class CurrencyRepository {
 
 extension CurrencyRepository {
     // table query
-    static let table = Table("CURRENCYFORMATS_V1")
+    static let table = SQLite.Table("CURRENCYFORMATS_V1")
 
     // table columns
-    static let col_id                 = Expression<Int64>("CURRENCYID")
-    static let col_name               = Expression<String>("CURRENCYNAME")
-    static let col_prefixSymbol       = Expression<String?>("PFX_SYMBOL")
-    static let col_suffixSymbol       = Expression<String?>("SFX_SYMBOL")
-    static let col_decimalPoint       = Expression<String?>("DECIMAL_POINT")
-    static let col_groupSeparator     = Expression<String?>("GROUP_SEPARATOR")
-    static let col_unitName           = Expression<String?>("UNIT_NAME")
-    static let col_centName           = Expression<String?>("CENT_NAME")
-    static let col_scale              = Expression<Int?>("SCALE")
-    static let col_baseConversionRate = Expression<Double?>("BASECONVRATE")
-    static let col_symbol             = Expression<String>("CURRENCY_SYMBOL")
-    static let col_type               = Expression<String>("CURRENCY_TYPE")
+    static let col_id                 = SQLite.Expression<Int64>("CURRENCYID")
+    static let col_name               = SQLite.Expression<String>("CURRENCYNAME")
+    static let col_prefixSymbol       = SQLite.Expression<String?>("PFX_SYMBOL")
+    static let col_suffixSymbol       = SQLite.Expression<String?>("SFX_SYMBOL")
+    static let col_decimalPoint       = SQLite.Expression<String?>("DECIMAL_POINT")
+    static let col_groupSeparator     = SQLite.Expression<String?>("GROUP_SEPARATOR")
+    static let col_unitName           = SQLite.Expression<String?>("UNIT_NAME")
+    static let col_centName           = SQLite.Expression<String?>("CENT_NAME")
+    static let col_scale              = SQLite.Expression<Int?>("SCALE")
+    static let col_baseConversionRate = SQLite.Expression<Double?>("BASECONVRATE")
+    static let col_symbol             = SQLite.Expression<String>("CURRENCY_SYMBOL")
+    static let col_type               = SQLite.Expression<String>("CURRENCY_TYPE")
 
     // cast NUMERIC to REAL
-    static let cast_baseConversionRate = cast(col_baseConversionRate) as Expression<Double?>
+    static let cast_baseConversionRate = cast(col_baseConversionRate) as SQLite.Expression<Double?>
 }
 
 extension CurrencyRepository {

--- a/MMEX/Repositories/InfoRepository.swift
+++ b/MMEX/Repositories/InfoRepository.swift
@@ -16,10 +16,11 @@ class InfoRepository {
     }
 
     func createTable() throws {
-        let infoTable = Table("INFOTABLE_V1")
-        let id = Expression<Int64>("ID")
-        let name = Expression<String>("INFONAME")
-        let value = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+
+        let id    = SQLite.Expression<Int64>("ID")
+        let name  = SQLite.Expression<String>("INFONAME")
+        let value = SQLite.Expression<String>("INFOVALUE")
         
         try db.run(infoTable.create(ifNotExists: true) { t in
             t.column(id, primaryKey: .autoincrement)
@@ -29,12 +30,12 @@ class InfoRepository {
     }
 
     func fetchInfo(by name: String) -> Info? {
-        let infoTable = Table("INFOTABLE_V1")
-        let nameExp = Expression<String>("INFONAME")
-        let valueExp = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+        let nameExp  = SQLite.Expression<String>("INFONAME")
+        let valueExp = SQLite.Expression<String>("INFOVALUE")
         
         if let row = try? db.pluck(infoTable.filter(nameExp == name)) {
-            let id = try row.get(Expression<Int64>("ID"))
+            let id = try row.get(SQLite.Expression<Int64>("ID"))
             let value = try row.get(valueExp)
             return Info(id: id, name: name, value: value)
         }
@@ -42,9 +43,9 @@ class InfoRepository {
     }
 
     func insertOrUpdate(info: Info) throws {
-        let infoTable = Table("INFOTABLE_V1")
-        let nameExp = Expression<String>("INFONAME")
-        let valueExp = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+        let nameExp  = SQLite.Expression<String>("INFONAME")
+        let valueExp = SQLite.Expression<String>("INFOVALUE")
 
         if let existing = fetchInfo(by: info.name) {
             try db.run(infoTable.filter(nameExp == info.name).update(valueExp <- info.value))

--- a/MMEX/Repositories/PayeeRepository.swift
+++ b/MMEX/Repositories/PayeeRepository.swift
@@ -18,17 +18,17 @@ class PayeeRepository {
 
 extension PayeeRepository {
     // table query
-    static let table = Table("PAYEE_V1")
+    static let table = SQLite.Table("PAYEE_V1")
 
     // table columns
-    static let col_id         = Expression<Int64>("PAYEEID")
-    static let col_name       = Expression<String>("PAYEENAME")
-    static let col_categoryId = Expression<Int64?>("CATEGID")
-    static let col_number     = Expression<String?>("NUMBER")
-    static let col_website    = Expression<String?>("WEBSITE")
-    static let col_notes      = Expression<String?>("NOTES")
-    static let col_active     = Expression<Int?>("ACTIVE")
-    static let col_pattern    = Expression<String>("PATTERN")
+    static let col_id         = SQLite.Expression<Int64>("PAYEEID")
+    static let col_name       = SQLite.Expression<String>("PAYEENAME")
+    static let col_categoryId = SQLite.Expression<Int64?>("CATEGID")
+    static let col_number     = SQLite.Expression<String?>("NUMBER")
+    static let col_website    = SQLite.Expression<String?>("WEBSITE")
+    static let col_notes      = SQLite.Expression<String?>("NOTES")
+    static let col_active     = SQLite.Expression<Int?>("ACTIVE")
+    static let col_pattern    = SQLite.Expression<String>("PATTERN")
 }
 
 extension PayeeRepository {

--- a/MMEX/Repositories/TransactionRepository.swift
+++ b/MMEX/Repositories/TransactionRepository.swift
@@ -18,34 +18,34 @@ class TransactionRepository {
 
 extension TransactionRepository {
     // table query
-    static let table = Table("CHECKINGACCOUNT_V1")
+    static let table = SQLite.Table("CHECKINGACCOUNT_V1")
 
     // table columns
-    static let col_id                = Expression<Int64>("TRANSID")
-    static let col_accountId         = Expression<Int64>("ACCOUNTID")
-    static let col_toAccountId       = Expression<Int64?>("TOACCOUNTID")
-    static let col_payeeId           = Expression<Int64>("PAYEEID")
-    static let col_transCode         = Expression<String>("TRANSCODE")
-    static let col_transAmount       = Expression<Double>("TRANSAMOUNT")
-    static let col_status            = Expression<String?>("STATUS")
-    static let col_transactionNumber = Expression<String?>("TRANSACTIONNUMBER")
-    static let col_notes             = Expression<String?>("NOTES")
-    static let col_categId           = Expression<Int64?>("CATEGID")
-    static let col_transDate         = Expression<String?>("TRANSDATE")
-    static let col_lastUpdatedTime   = Expression<String?>("LASTUPDATEDTIME")
-    static let col_deletedTime       = Expression<String?>("DELETEDTIME")
-    static let col_followUpId        = Expression<Int64?>("FOLLOWUPID")
-    static let col_toTransAmount     = Expression<Double?>("TOTRANSAMOUNT")
-    static let col_color             = Expression<Int64>("COLOR")
+    static let col_id                = SQLite.Expression<Int64>("TRANSID")
+    static let col_accountId         = SQLite.Expression<Int64>("ACCOUNTID")
+    static let col_toAccountId       = SQLite.Expression<Int64?>("TOACCOUNTID")
+    static let col_payeeId           = SQLite.Expression<Int64>("PAYEEID")
+    static let col_transCode         = SQLite.Expression<String>("TRANSCODE")
+    static let col_transAmount       = SQLite.Expression<Double>("TRANSAMOUNT")
+    static let col_status            = SQLite.Expression<String?>("STATUS")
+    static let col_transactionNumber = SQLite.Expression<String?>("TRANSACTIONNUMBER")
+    static let col_notes             = SQLite.Expression<String?>("NOTES")
+    static let col_categId           = SQLite.Expression<Int64?>("CATEGID")
+    static let col_transDate         = SQLite.Expression<String?>("TRANSDATE")
+    static let col_lastUpdatedTime   = SQLite.Expression<String?>("LASTUPDATEDTIME")
+    static let col_deletedTime       = SQLite.Expression<String?>("DELETEDTIME")
+    static let col_followUpId        = SQLite.Expression<Int64?>("FOLLOWUPID")
+    static let col_toTransAmount     = SQLite.Expression<Double?>("TOTRANSAMOUNT")
+    static let col_color             = SQLite.Expression<Int64>("COLOR")
 
     // cast NUMERIC to REAL
-    static let cast_transAmount   = cast(col_transAmount)   as Expression<Double>
-    static let cast_toTransAmount = cast(col_toTransAmount) as Expression<Double?>
+    static let cast_transAmount   = cast(col_transAmount)   as SQLite.Expression<Double>
+    static let cast_toTransAmount = cast(col_toTransAmount) as SQLite.Expression<Double?>
 }
     
 extension TransactionRepository {
     // select query
-    static func selectQuery(from: Table) -> Table {
+    static func selectQuery(from: SQLite.Table) -> SQLite.Table {
         return from.select(
             col_id,
             col_accountId,
@@ -123,7 +123,7 @@ extension TransactionRepository {
         return table.filter(col_id == txn.id).delete()
     }
 }
-    
+
 extension TransactionRepository {
     // load all transactions
     func loadTransactions() -> [Transaction] {
@@ -141,7 +141,7 @@ extension TransactionRepository {
             return []
         }
     }
-    
+
     // load recent transactions
     func loadRecentTransactions(
         startDate: Date? = Calendar.current.date(byAdding: .month, value: -3, to: Date()),


### PR DESCRIPTION
After update to Xcode 16.0, I cannot compile. Seems that `Foundation` also defines `Expression` and there is a name collision. I couldn't find a way to declare in Swift that `Expression` must be taken from `SQLite`.

This PR adds the prefix `SQLite.` in front of `Table` and `Expression`.

Note: I also tried to remove `Foundation`, or to import from it only the names that are needed, effectively making `SQLite` the only fully imported library. It works (with less changes in the code), but I think adding an `SQLite.` prefix is more robust and more clean.