### PR TITLE
add "SQLite." prefix in Table, Expression

### DIFF
--- a/MMEX/Models/Infotable.swift
+++ b/MMEX/Models/Infotable.swift
@@ -56,9 +56,9 @@ extension Infotable {
 extension Infotable {
     static var empty: Infotable { Infotable(id: 0, name: "", value: "") }
 
-    static let table = Table("INFOTABLE_V1")
+    static let table = SQLite.Table("INFOTABLE_V1")
 
-    static let infoID = Expression<Int64>("INFOID")
-    static let infoName = Expression<String>("INFONAME")
-    static let infoValue = Expression<String>("INFOVALUE")
+    static let infoID    = SQLite.Expression<Int64>("INFOID")
+    static let infoName  = SQLite.Expression<String>("INFONAME")
+    static let infoValue = SQLite.Expression<String>("INFOVALUE")
 }

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -18,37 +18,37 @@ class AccountRepository {
 
 extension AccountRepository {
     // table query
-    static let table = Table("ACCOUNTLIST_V1")
+    static let table = SQLite.Table("ACCOUNTLIST_V1")
 
     // table columns
-    static let col_id              = Expression<Int64>("ACCOUNTID")
-    static let col_name            = Expression<String>("ACCOUNTNAME")
-    static let col_type            = Expression<String>("ACCOUNTTYPE")
-    static let col_num             = Expression<String?>("ACCOUNTNUM")
-    static let col_status          = Expression<String>("STATUS")
-    static let col_notes           = Expression<String?>("NOTES")
-    static let col_heldAt          = Expression<String?>("HELDAT")
-    static let col_website         = Expression<String?>("WEBSITE")
-    static let col_contactInfo     = Expression<String?>("CONTACTINFO")
-    static let col_accessInfo      = Expression<String?>("ACCESSINFO")
-    static let col_initialDate     = Expression<String?>("INITIALDATE")
-    static let col_initialBal      = Expression<Double?>("INITIALBAL")
-    static let col_favoriteAcct    = Expression<String>("FAVORITEACCT")
-    static let col_currencyId      = Expression<Int64>("CURRENCYID")
-    static let col_statementLocked = Expression<Int?>("STATEMENTLOCKED")
-    static let col_statementDate   = Expression<String?>("STATEMENTDATE")
-    static let col_minimumBalance  = Expression<Double?>("MINIMUMBALANCE")
-    static let col_creditLimit     = Expression<Double?>("CREDITLIMIT")
-    static let col_interestRate    = Expression<Double?>("INTERESTRATE")
-    static let col_paymentDueDate  = Expression<String?>("PAYMENTDUEDATE")
-    static let col_minimumPayment  = Expression<Double?>("MINIMUMPAYMENT")
+    static let col_id              = SQLite.Expression<Int64>("ACCOUNTID")
+    static let col_name            = SQLite.Expression<String>("ACCOUNTNAME")
+    static let col_type            = SQLite.Expression<String>("ACCOUNTTYPE")
+    static let col_num             = SQLite.Expression<String?>("ACCOUNTNUM")
+    static let col_status          = SQLite.Expression<String>("STATUS")
+    static let col_notes           = SQLite.Expression<String?>("NOTES")
+    static let col_heldAt          = SQLite.Expression<String?>("HELDAT")
+    static let col_website         = SQLite.Expression<String?>("WEBSITE")
+    static let col_contactInfo     = SQLite.Expression<String?>("CONTACTINFO")
+    static let col_accessInfo      = SQLite.Expression<String?>("ACCESSINFO")
+    static let col_initialDate     = SQLite.Expression<String?>("INITIALDATE")
+    static let col_initialBal      = SQLite.Expression<Double?>("INITIALBAL")
+    static let col_favoriteAcct    = SQLite.Expression<String>("FAVORITEACCT")
+    static let col_currencyId      = SQLite.Expression<Int64>("CURRENCYID")
+    static let col_statementLocked = SQLite.Expression<Int?>("STATEMENTLOCKED")
+    static let col_statementDate   = SQLite.Expression<String?>("STATEMENTDATE")
+    static let col_minimumBalance  = SQLite.Expression<Double?>("MINIMUMBALANCE")
+    static let col_creditLimit     = SQLite.Expression<Double?>("CREDITLIMIT")
+    static let col_interestRate    = SQLite.Expression<Double?>("INTERESTRATE")
+    static let col_paymentDueDate  = SQLite.Expression<String?>("PAYMENTDUEDATE")
+    static let col_minimumPayment  = SQLite.Expression<Double?>("MINIMUMPAYMENT")
 
     // cast NUMERIC to REAL
-    static let cast_initialBal     = cast(col_initialBal)     as Expression<Double?>
-    static let cast_minimumBalance = cast(col_minimumBalance) as Expression<Double?>
-    static let cast_creditLimit    = cast(col_creditLimit)    as Expression<Double?>
-    static let cast_interestRate   = cast(col_interestRate)   as Expression<Double?>
-    static let cast_minimumPayment = cast(col_minimumPayment) as Expression<Double?>
+    static let cast_initialBal     = cast(col_initialBal)     as SQLite.Expression<Double?>
+    static let cast_minimumBalance = cast(col_minimumBalance) as SQLite.Expression<Double?>
+    static let cast_creditLimit    = cast(col_creditLimit)    as SQLite.Expression<Double?>
+    static let cast_interestRate   = cast(col_interestRate)   as SQLite.Expression<Double?>
+    static let cast_minimumPayment = cast(col_minimumPayment) as SQLite.Expression<Double?>
 }
 
 extension AccountRepository {

--- a/MMEX/Repositories/CategoryRepository.swift
+++ b/MMEX/Repositories/CategoryRepository.swift
@@ -17,13 +17,13 @@ class CategoryRepository {
 
 extension CategoryRepository {
     // table query
-    static let table = Table("CATEGORY_V1")
+    static let table = SQLite.Table("CATEGORY_V1")
 
     // table columns
-    static let col_id       = Expression<Int64>("CATEGID")
-    static let col_name     = Expression<String>("CATEGNAME")
-    static let col_active   = Expression<Int?>("ACTIVE")
-    static let col_parentId = Expression<Int64?>("PARENTID")
+    static let col_id       = SQLite.Expression<Int64>("CATEGID")
+    static let col_name     = SQLite.Expression<String>("CATEGNAME")
+    static let col_active   = SQLite.Expression<Int?>("ACTIVE")
+    static let col_parentId = SQLite.Expression<Int64?>("PARENTID")
 }
 
 extension CategoryRepository {

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -18,24 +18,24 @@ class CurrencyRepository {
 
 extension CurrencyRepository {
     // table query
-    static let table = Table("CURRENCYFORMATS_V1")
+    static let table = SQLite.Table("CURRENCYFORMATS_V1")
 
     // table columns
-    static let col_id                 = Expression<Int64>("CURRENCYID")
-    static let col_name               = Expression<String>("CURRENCYNAME")
-    static let col_prefixSymbol       = Expression<String?>("PFX_SYMBOL")
-    static let col_suffixSymbol       = Expression<String?>("SFX_SYMBOL")
-    static let col_decimalPoint       = Expression<String?>("DECIMAL_POINT")
-    static let col_groupSeparator     = Expression<String?>("GROUP_SEPARATOR")
-    static let col_unitName           = Expression<String?>("UNIT_NAME")
-    static let col_centName           = Expression<String?>("CENT_NAME")
-    static let col_scale              = Expression<Int?>("SCALE")
-    static let col_baseConversionRate = Expression<Double?>("BASECONVRATE")
-    static let col_symbol             = Expression<String>("CURRENCY_SYMBOL")
-    static let col_type               = Expression<String>("CURRENCY_TYPE")
+    static let col_id                 = SQLite.Expression<Int64>("CURRENCYID")
+    static let col_name               = SQLite.Expression<String>("CURRENCYNAME")
+    static let col_prefixSymbol       = SQLite.Expression<String?>("PFX_SYMBOL")
+    static let col_suffixSymbol       = SQLite.Expression<String?>("SFX_SYMBOL")
+    static let col_decimalPoint       = SQLite.Expression<String?>("DECIMAL_POINT")
+    static let col_groupSeparator     = SQLite.Expression<String?>("GROUP_SEPARATOR")
+    static let col_unitName           = SQLite.Expression<String?>("UNIT_NAME")
+    static let col_centName           = SQLite.Expression<String?>("CENT_NAME")
+    static let col_scale              = SQLite.Expression<Int?>("SCALE")
+    static let col_baseConversionRate = SQLite.Expression<Double?>("BASECONVRATE")
+    static let col_symbol             = SQLite.Expression<String>("CURRENCY_SYMBOL")
+    static let col_type               = SQLite.Expression<String>("CURRENCY_TYPE")
 
     // cast NUMERIC to REAL
-    static let cast_baseConversionRate = cast(col_baseConversionRate) as Expression<Double?>
+    static let cast_baseConversionRate = cast(col_baseConversionRate) as SQLite.Expression<Double?>
 }
 
 extension CurrencyRepository {

--- a/MMEX/Repositories/InfoRepository.swift
+++ b/MMEX/Repositories/InfoRepository.swift
@@ -16,10 +16,11 @@ class InfoRepository {
     }
 
     func createTable() throws {
-        let infoTable = Table("INFOTABLE_V1")
-        let id = Expression<Int64>("ID")
-        let name = Expression<String>("INFONAME")
-        let value = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+
+        let id    = SQLite.Expression<Int64>("ID")
+        let name  = SQLite.Expression<String>("INFONAME")
+        let value = SQLite.Expression<String>("INFOVALUE")
         
         try db.run(infoTable.create(ifNotExists: true) { t in
             t.column(id, primaryKey: .autoincrement)
@@ -29,12 +30,12 @@ class InfoRepository {
     }
 
     func fetchInfo(by name: String) -> Info? {
-        let infoTable = Table("INFOTABLE_V1")
-        let nameExp = Expression<String>("INFONAME")
-        let valueExp = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+        let nameExp  = SQLite.Expression<String>("INFONAME")
+        let valueExp = SQLite.Expression<String>("INFOVALUE")
         
         if let row = try? db.pluck(infoTable.filter(nameExp == name)) {
-            let id = try row.get(Expression<Int64>("ID"))
+            let id = try row.get(SQLite.Expression<Int64>("ID"))
             let value = try row.get(valueExp)
             return Info(id: id, name: name, value: value)
         }
@@ -42,9 +43,9 @@ class InfoRepository {
     }
 
     func insertOrUpdate(info: Info) throws {
-        let infoTable = Table("INFOTABLE_V1")
-        let nameExp = Expression<String>("INFONAME")
-        let valueExp = Expression<String>("INFOVALUE")
+        let infoTable = SQLite.Table("INFOTABLE_V1")
+        let nameExp  = SQLite.Expression<String>("INFONAME")
+        let valueExp = SQLite.Expression<String>("INFOVALUE")
 
         if let existing = fetchInfo(by: info.name) {
             try db.run(infoTable.filter(nameExp == info.name).update(valueExp <- info.value))

--- a/MMEX/Repositories/PayeeRepository.swift
+++ b/MMEX/Repositories/PayeeRepository.swift
@@ -18,17 +18,17 @@ class PayeeRepository {
 
 extension PayeeRepository {
     // table query
-    static let table = Table("PAYEE_V1")
+    static let table = SQLite.Table("PAYEE_V1")
 
     // table columns
-    static let col_id         = Expression<Int64>("PAYEEID")
-    static let col_name       = Expression<String>("PAYEENAME")
-    static let col_categoryId = Expression<Int64?>("CATEGID")
-    static let col_number     = Expression<String?>("NUMBER")
-    static let col_website    = Expression<String?>("WEBSITE")
-    static let col_notes      = Expression<String?>("NOTES")
-    static let col_active     = Expression<Int?>("ACTIVE")
-    static let col_pattern    = Expression<String>("PATTERN")
+    static let col_id         = SQLite.Expression<Int64>("PAYEEID")
+    static let col_name       = SQLite.Expression<String>("PAYEENAME")
+    static let col_categoryId = SQLite.Expression<Int64?>("CATEGID")
+    static let col_number     = SQLite.Expression<String?>("NUMBER")
+    static let col_website    = SQLite.Expression<String?>("WEBSITE")
+    static let col_notes      = SQLite.Expression<String?>("NOTES")
+    static let col_active     = SQLite.Expression<Int?>("ACTIVE")
+    static let col_pattern    = SQLite.Expression<String>("PATTERN")
 }
 
 extension PayeeRepository {

--- a/MMEX/Repositories/TransactionRepository.swift
+++ b/MMEX/Repositories/TransactionRepository.swift
@@ -18,34 +18,34 @@ class TransactionRepository {
 
 extension TransactionRepository {
     // table query
-    static let table = Table("CHECKINGACCOUNT_V1")
+    static let table = SQLite.Table("CHECKINGACCOUNT_V1")
 
     // table columns
-    static let col_id                = Expression<Int64>("TRANSID")
-    static let col_accountId         = Expression<Int64>("ACCOUNTID")
-    static let col_toAccountId       = Expression<Int64?>("TOACCOUNTID")
-    static let col_payeeId           = Expression<Int64>("PAYEEID")
-    static let col_transCode         = Expression<String>("TRANSCODE")
-    static let col_transAmount       = Expression<Double>("TRANSAMOUNT")
-    static let col_status            = Expression<String?>("STATUS")
-    static let col_transactionNumber = Expression<String?>("TRANSACTIONNUMBER")
-    static let col_notes             = Expression<String?>("NOTES")
-    static let col_categId           = Expression<Int64?>("CATEGID")
-    static let col_transDate         = Expression<String?>("TRANSDATE")
-    static let col_lastUpdatedTime   = Expression<String?>("LASTUPDATEDTIME")
-    static let col_deletedTime       = Expression<String?>("DELETEDTIME")
-    static let col_followUpId        = Expression<Int64?>("FOLLOWUPID")
-    static let col_toTransAmount     = Expression<Double?>("TOTRANSAMOUNT")
-    static let col_color             = Expression<Int64>("COLOR")
+    static let col_id                = SQLite.Expression<Int64>("TRANSID")
+    static let col_accountId         = SQLite.Expression<Int64>("ACCOUNTID")
+    static let col_toAccountId       = SQLite.Expression<Int64?>("TOACCOUNTID")
+    static let col_payeeId           = SQLite.Expression<Int64>("PAYEEID")
+    static let col_transCode         = SQLite.Expression<String>("TRANSCODE")
+    static let col_transAmount       = SQLite.Expression<Double>("TRANSAMOUNT")
+    static let col_status            = SQLite.Expression<String?>("STATUS")
+    static let col_transactionNumber = SQLite.Expression<String?>("TRANSACTIONNUMBER")
+    static let col_notes             = SQLite.Expression<String?>("NOTES")
+    static let col_categId           = SQLite.Expression<Int64?>("CATEGID")
+    static let col_transDate         = SQLite.Expression<String?>("TRANSDATE")
+    static let col_lastUpdatedTime   = SQLite.Expression<String?>("LASTUPDATEDTIME")
+    static let col_deletedTime       = SQLite.Expression<String?>("DELETEDTIME")
+    static let col_followUpId        = SQLite.Expression<Int64?>("FOLLOWUPID")
+    static let col_toTransAmount     = SQLite.Expression<Double?>("TOTRANSAMOUNT")
+    static let col_color             = SQLite.Expression<Int64>("COLOR")
 
     // cast NUMERIC to REAL
-    static let cast_transAmount   = cast(col_transAmount)   as Expression<Double>
-    static let cast_toTransAmount = cast(col_toTransAmount) as Expression<Double?>
+    static let cast_transAmount   = cast(col_transAmount)   as SQLite.Expression<Double>
+    static let cast_toTransAmount = cast(col_toTransAmount) as SQLite.Expression<Double?>
 }
     
 extension TransactionRepository {
     // select query
-    static func selectQuery(from: Table) -> Table {
+    static func selectQuery(from: SQLite.Table) -> SQLite.Table {
         return from.select(
             col_id,
             col_accountId,
@@ -123,7 +123,7 @@ extension TransactionRepository {
         return table.filter(col_id == txn.id).delete()
     }
 }
-    
+
 extension TransactionRepository {
     // load all transactions
     func loadTransactions() -> [Transaction] {
@@ -141,7 +141,7 @@ extension TransactionRepository {
             return []
         }
     }
-    
+
     // load recent transactions
     func loadRecentTransactions(
         startDate: Date? = Calendar.current.date(byAdding: .month, value: -3, to: Date()),


### PR DESCRIPTION
(This PR is the same as #10, but with `MMEX.xcodeproj` excluded).

After update to Xcode 16.0, I cannot compile. Seems that Foundation also defines Expression and there is a name collision. I couldn't find a way to declare in Swift that Expression must be taken from SQLite.

This PR adds the prefix SQLite. in front of Table and Expression.

Note: I also tried to remove Foundation, or to import from it only the names that are needed, effectively making SQLite the only fully imported library. It works (with less changes in the code), but I think adding an SQLite. prefix is more robust and more clean.