### PR TITLE
refactor DB comments, Infotable

### DIFF
--- a/MMEX/Models/Account.swift
+++ b/MMEX/Models/Account.swift
@@ -35,27 +35,27 @@ enum AccountType: String, CaseIterable, Identifiable, Codable {
 }
 
 struct Account: ExportableEntity {
-    var id: Int64               // ACCOUNTID INTEGER PRIMARY KEY
-    var name: String            // ACCOUNTNAME TEXT COLLATE NOCASE NOT NULL UNIQUE
-    var type: AccountType       // ACCOUNTTYPE TEXT NOT NULL (Cash, Checking, ...)
-    var num: String?            // ACCOUNTNUM TEXT
-    var status: AccountStatus   // STATUS TEXT NOT NULL (Open, Closed)
-    var notes: String?          // NOTES TEXT
-    var heldAt: String?         // HELDAT TEXT
-    var website: String?        // WEBSITE TEXT
-    var contactInfo: String?    // CONTACTINFO TEXT
-    var accessInfo: String?     // ACCESSINFO TEXT
-    var initialDate: String?    // INITIALDATE TEXT
-    var initialBal: Double?     // INITIALBAL NUMERIC
-    var favoriteAcct: String    // FAVORITEACCT NOT NULL TEXT
-    var currencyId: Int64       // CURRENCYID NOT NULL INTEGER
-    var statementLocked: Bool?  // STATEMENTLOCKED INTEGER
-    var statementDate: String?  // STATEMENTDATE TEXT
-    var minimumBalance: Double? // MINIMUMBALANCE NUMERIC
-    var creditLimit: Double?    // CREDITLIMIT NUMERIC
-    var interestRate: Double?   // INTERESTRATE NUMERIC
-    var paymentDueDate: String? // PAYMENTDUEDATE TEXT
-    var minimumPayment: Double? // MINIMUMPAYMENT NUMERIC
+    var id: Int64
+    var name: String
+    var type: AccountType
+    var num: String?
+    var status: AccountStatus
+    var notes: String?
+    var heldAt: String?
+    var website: String?
+    var contactInfo: String?
+    var accessInfo: String?
+    var initialDate: String?
+    var initialBal: Double?
+    var favoriteAcct: String
+    var currencyId: Int64
+    var statementLocked: Bool?
+    var statementDate: String?
+    var minimumBalance: Double?
+    var creditLimit: Double?
+    var interestRate: Double?
+    var paymentDueDate: String?
+    var minimumPayment: Double?
 
     var currency: Currency?
 

--- a/MMEX/Models/Category.swift
+++ b/MMEX/Models/Category.swift
@@ -9,11 +9,10 @@ import Foundation
 import SQLite
 
 struct Category: ExportableEntity {
-    var id: Int64        // CATEGID INTEGER PRIMARY KEY
-    var name: String     // CATEGNAME TEXT COLLATE NOCASE NOT NULL
-    var active: Bool?    // ACTIVE INTEGER
-    var parentId: Int64? // PARENTID INTEGER
-                         // UNIQUE(CATEGNAME, PARENTID)
+    var id: Int64
+    var name: String
+    var active: Bool?
+    var parentId: Int64?
 }
 
 extension Category {

--- a/MMEX/Models/Currency.swift
+++ b/MMEX/Models/Currency.swift
@@ -9,18 +9,18 @@ import Foundation
 import SQLite
 
 struct Currency: ExportableEntity {
-    var id: Int64                   // CURRENCYID INTEGER PRIMARY KEY
-    var name: String                // CURRENCYNAME TEXT COLLATE NOCASE NOT NULL UNIQUE
-    var prefixSymbol: String?       // PFX_SYMBOL TEXT
-    var suffixSymbol: String?       // SFX_SYMBOL TEXT
-    var decimalPoint: String?       // DECIMAL_POINT TEXT
-    var groupSeparator: String?     // GROUP_SEPARATOR TEXT
-    var unitName: String?           // UNIT_NAME TEXT COLLATE NOCASE
-    var centName: String?           // CENT_NAME TEXT COLLATE NOCASE
-    var scale: Int?                 // SCALE INTEGER
-    var baseConversionRate: Double? // BASECONVRATE NUMERIC
-    var symbol: String              // CURRENCY_SYMBOL TEXT COLLATE NOCASE NOT NULL UNIQUE
-    var type: String                // CURRENCY_TYPE TEXT NOT NULL (Fiat, Crypto)
+    var id: Int64
+    var name: String
+    var prefixSymbol: String?
+    var suffixSymbol: String?
+    var decimalPoint: String?
+    var groupSeparator: String?
+    var unitName: String?
+    var centName: String?
+    var scale: Int?
+    var baseConversionRate: Double?
+    var symbol: String
+    var type: String
 }
 
 extension Currency {

--- a/MMEX/Models/Infotable.swift
+++ b/MMEX/Models/Infotable.swift
@@ -47,18 +47,13 @@ struct Infotable: ExportableEntity {
 }
 
 extension Infotable {
-    static let sampleData: [Infotable] =
-    [
-        Infotable(id: 1, name: "DATAVERSION", value: "3")
-    ]
+    static var empty: Infotable { Infotable(
+        id: 0, name: "", value: ""
+    ) }
 }
 
 extension Infotable {
-    static var empty: Infotable { Infotable(id: 0, name: "", value: "") }
-
-    static let table = SQLite.Table("INFOTABLE_V1")
-
-    static let infoID    = SQLite.Expression<Int64>("INFOID")
-    static let infoName  = SQLite.Expression<String>("INFONAME")
-    static let infoValue = SQLite.Expression<String>("INFOVALUE")
+    static let sampleData: [Infotable] = [
+        Infotable(id: 1, name: "DATAVERSION", value: "3"),
+    ]
 }

--- a/MMEX/Models/Payee.swift
+++ b/MMEX/Models/Payee.swift
@@ -9,14 +9,14 @@ import Foundation
 import SQLite
 
 struct Payee: ExportableEntity {
-    var id: Int64          // PAYEEID INTEGER PRIMARY KEY
-    var name: String       // PAYEENAME TEXT COLLATE NOCASE NOT NULL UNIQUE
-    var categoryId: Int64? // CATEGID INTEGER
-    var number: String?    // NUMBER TEXT
-    var website: String?   // WEBSITE TEXT
-    var notes: String?     // NOTES TEXT
-    var active: Int?       // ACTIVE INTEGER
-    var pattern: String    // PATTERN TEXT DEFAULT ''
+    var id: Int64
+    var name: String
+    var categoryId: Int64?
+    var number: String?
+    var website: String?
+    var notes: String?
+    var active: Int?
+    var pattern: String
 
     init(
         id: Int64, name: String, categoryId: Int64? = nil, number: String? = nil,

--- a/MMEX/Models/Transaction.swift
+++ b/MMEX/Models/Transaction.swift
@@ -42,23 +42,23 @@ enum TransactionStatus: String, CaseIterable, Identifiable, Codable {
 }
 
 struct Transaction: ExportableEntity {
-    var id: Int64                  // TRANSID INTEGER PRIMARY KEY
-    var accountId: Int64           // ACCOUNTID INTEGER NOT NULL
-    var toAccountId: Int64?        // TOACCOUNTID INTEGER
-    var payeeId: Int64             // PAYEEID INTEGER NOT NULL
-    var transCode: Transcode       // TRANSCODE TEXT NOT NULL
-    var transAmount: Double        // TRANSAMOUNT NUMERIC NOT NULL
-    var status: TransactionStatus  // STATUS TEXT
-    var transactionNumber: String? // TRANSACTIONNUMBER TEXT
-    var notes: String?             // NOTES TEXT
-    var categId: Int64?            // CATEGID INTEGER
-    var transDate: String?         // TRANSDATE TEXT
-    var lastUpdatedTime: String?   // LASTUPDATEDTIME TEXT
-    var deletedTime: String?       // DELETEDTIME TEXT
-    var followUpId: Int64?         // FOLLOWUPID INTEGER
-    var toTransAmount: Double?     // TOTRANSAMOUNT NUMERIC
-    var color: Int64               // COLOR INTEGER DEFAULT -1
-    
+    var id: Int64
+    var accountId: Int64
+    var toAccountId: Int64?
+    var payeeId: Int64
+    var transCode: Transcode
+    var transAmount: Double
+    var status: TransactionStatus
+    var transactionNumber: String?
+    var notes: String?
+    var categId: Int64?
+    var transDate: String?
+    var lastUpdatedTime: String?
+    var deletedTime: String?
+    var followUpId: Int64?
+    var toTransAmount: Double?
+    var color: Int64
+
     init(
         id: Int64, accountId: Int64, toAccountId: Int64? = nil, payeeId: Int64,
         transCode: Transcode, transAmount: Double, status: TransactionStatus,

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -20,6 +20,30 @@ extension AccountRepository {
     // table query
     static let table = SQLite.Table("ACCOUNTLIST_V1")
 
+    // column          | type    | other
+    // ----------------+---------+------
+    // ACCOUNTID       | INTEGER | PRIMARY KEY
+    // ACCOUNTNAME     | TEXT    | COLLATE NOCASE NOT NULL UNIQUE
+    // ACCOUNTTYPE     | TEXT    | NOT NULL (Cash, Checking, ...)
+    // ACCOUNTNUM      | TEXT    |
+    // STATUS          | TEXT    | NOT NULL (Open, Closed)
+    // NOTES           | TEXT    |
+    // HELDAT          | TEXT    |
+    // WEBSITE         | TEXT    |
+    // CONTACTINFO     | TEXT    |
+    // ACCESSINFO      | TEXT    |
+    // INITIALDATE     | TEXT    |
+    // INITIALBAL      | NUMERIC |
+    // FAVORITEACCT    | TEXT    | NOT NULL
+    // CURRENCYID      | INTEGER | NOT NULL
+    // STATEMENTLOCKED | INTEGER |
+    // STATEMENTDATE   | TEXT    |
+    // MINIMUMBALANCE  | NUMERIC |
+    // CREDITLIMIT     | NUMERIC |
+    // INTERESTRATE    | NUMERIC |
+    // PAYMENTDUEDATE  | TEXT    |
+    // MINIMUMPAYMENT  | NUMERIC |
+
     // table columns
     static let col_id              = SQLite.Expression<Int64>("ACCOUNTID")
     static let col_name            = SQLite.Expression<String>("ACCOUNTNAME")
@@ -131,17 +155,17 @@ extension AccountRepository {
     }
 
     // insert query
-    static func insertQuery(_ account: Account) -> Insert {
+    static func insertQuery(_ account: Account) -> SQLite.Insert {
         return table.insert(insertSetters(account))
     }
 
     // update query
-    static func updateQuery(_ account: Account) -> Update {
+    static func updateQuery(_ account: Account) -> SQLite.Update {
         return table.filter(col_id == account.id).update(insertSetters(account))
     }
 
     // delete query
-    static func deleteQuery(_ account: Account) -> Delete {
+    static func deleteQuery(_ account: Account) -> SQLite.Delete {
         return table.filter(col_id == account.id).delete()
     }
 }

--- a/MMEX/Repositories/CategoryRepository.swift
+++ b/MMEX/Repositories/CategoryRepository.swift
@@ -19,6 +19,14 @@ extension CategoryRepository {
     // table query
     static let table = SQLite.Table("CATEGORY_V1")
 
+    // column    | type    | other
+    // ----------+---------+------
+    //           |         | UNIQUE(CATEGNAME, PARENTID)
+    // CATEGID   | INTEGER | PRIMARY KEY
+    // CATEGNAME | TEXT    | COLLATE NOCASE NOT NULL
+    // ACTIVE    | INTEGER |
+    // PARENTID  | INTEGER |
+
     // table columns
     static let col_id       = SQLite.Expression<Int64>("CATEGID")
     static let col_name     = SQLite.Expression<String>("CATEGNAME")
@@ -46,7 +54,7 @@ extension CategoryRepository {
     }
 
     // insert query
-    static func insertQuery(_ category: Category) -> Insert {
+    static func insertQuery(_ category: Category) -> SQLite.Insert {
         return table.insert(
             col_name     <- category.name,
             col_active   <- category.active ?? false ? 1 : 0,
@@ -55,7 +63,7 @@ extension CategoryRepository {
     }
 
     // update query
-    static func updateQuery(_ category: Category) -> Update {
+    static func updateQuery(_ category: Category) -> SQLite.Update {
         return table.filter(col_id == category.id).update(
             col_name     <- category.name,
             col_active   <- category.active ?? false ? 1 : 0,
@@ -64,7 +72,7 @@ extension CategoryRepository {
     }
 
     // delete query
-    static func deleteQuery(_ category: Category) -> Delete {
+    static func deleteQuery(_ category: Category) -> SQLite.Delete {
         return table.filter(col_id == category.id).delete()
     }
 }

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -20,6 +20,21 @@ extension CurrencyRepository {
     // table query
     static let table = SQLite.Table("CURRENCYFORMATS_V1")
 
+    // column          | type    | other
+    // ----------------+---------+------
+    // CURRENCYID      | INTEGER | PRIMARY KEY
+    // CURRENCYNAME    | TEXT    | COLLATE NOCASE NOT NULL UNIQUE
+    // PFX_SYMBOL      | TEXT    |
+    // SFX_SYMBOL      | TEXT    |
+    // DECIMAL_POINT   | TEXT    |
+    // GROUP_SEPARATOR | TEXT    |
+    // UNIT_NAME       | TEXT    | COLLATE NOCASE
+    // CENT_NAME       | TEXT    | COLLATE NOCASE
+    // SCALE           | INTEGER |
+    // BASECONVRATE    | NUMERIC |
+    // CURRENCY_SYMBOL | TEXT    | COLLATE NOCASE NOT NULL UNIQUE
+    // CURRENCY_TYPE   | TEXT    | NOT NULL (Fiat, Crypto)
+
     // table columns
     static let col_id                 = SQLite.Expression<Int64>("CURRENCYID")
     static let col_name               = SQLite.Expression<String>("CURRENCYNAME")
@@ -74,7 +89,7 @@ extension CurrencyRepository {
     }
 
     // insert query
-    static func insertQuery(_ currency: Currency) -> Insert {
+    static func insertQuery(_ currency: Currency) -> SQLite.Insert {
         return table.insert(
             col_name               <- currency.name,
             col_prefixSymbol       <- currency.prefixSymbol,
@@ -91,7 +106,7 @@ extension CurrencyRepository {
     }
 
     // update query
-    static func updateQuery(_ currency: Currency) -> Update {
+    static func updateQuery(_ currency: Currency) -> SQLite.Update {
         return table.filter(col_id == currency.id).update(
             col_name               <- currency.name,
             col_prefixSymbol       <- currency.prefixSymbol,
@@ -108,7 +123,7 @@ extension CurrencyRepository {
     }
 
     // delete query
-    static func deleteQuery(_ currency: Currency) -> Delete {
+    static func deleteQuery(_ currency: Currency) -> SQLite.Delete {
         return table.filter(col_id == currency.id).delete()
     }
 }

--- a/MMEX/Repositories/PayeeRepository.swift
+++ b/MMEX/Repositories/PayeeRepository.swift
@@ -20,6 +20,17 @@ extension PayeeRepository {
     // table query
     static let table = SQLite.Table("PAYEE_V1")
 
+    // column    | type    | other
+    // ----------+---------+------
+    // PAYEEID   | INTEGER | PRIMARY KEY
+    // PAYEENAME | TEXT    | COLLATE NOCASE NOT NULL UNIQUE
+    // CATEGID   | INTEGER |
+    // NUMBER    | TEXT    |
+    // WEBSITE   | TEXT    |
+    // NOTES     | TEXT    |
+    // ACTIVE    | INTEGER |
+    // PATTERN   | TEXT    | DEFAULT ''
+
     // table columns
     static let col_id         = SQLite.Expression<Int64>("PAYEEID")
     static let col_name       = SQLite.Expression<String>("PAYEENAME")
@@ -59,7 +70,7 @@ extension PayeeRepository {
     }
 
     // insert query
-    static func insertQuery(_ payee: Payee) -> Insert {
+    static func insertQuery(_ payee: Payee) -> SQLite.Insert {
         return table.insert(
             col_name       <- payee.name,
             col_categoryId <- payee.categoryId,
@@ -72,7 +83,7 @@ extension PayeeRepository {
     }
 
     // update query
-    static func updateQuery(_ payee: Payee) -> Update {
+    static func updateQuery(_ payee: Payee) -> SQLite.Update {
         return table.filter(col_id == payee.id).update(
             col_name       <- payee.name,
             col_categoryId <- payee.categoryId,
@@ -85,7 +96,7 @@ extension PayeeRepository {
     }
 
     // delete query
-    static func deleteQuery(_ payee: Payee) -> Delete {
+    static func deleteQuery(_ payee: Payee) -> SQLite.Delete {
         return table.filter(col_id == payee.id).delete()
     }
 }

--- a/MMEX/Repositories/TransactionRepository.swift
+++ b/MMEX/Repositories/TransactionRepository.swift
@@ -20,6 +20,25 @@ extension TransactionRepository {
     // table query
     static let table = SQLite.Table("CHECKINGACCOUNT_V1")
 
+    // column            | type    | other
+    // ------------------+---------+------
+    // TRANSID           | INTEGER | PRIMARY KEY
+    // ACCOUNTID         | INTEGER | NOT NULL
+    // TOACCOUNTID       | INTEGER |
+    // PAYEEID           | INTEGER | NOT NULL
+    // TRANSCODE         | TEXT    | NOT NULL
+    // TRANSAMOUNT       | NUMERIC | NOT NULL
+    // STATUS            | TEXT    |
+    // TRANSACTIONNUMBER | TEXT    |
+    // NOTES             | TEXT    |
+    // CATEGID           | INTEGER |
+    // TRANSDATE         | TEXT    |
+    // LASTUPDATEDTIME   | TEXT    |
+    // DELETEDTIME       | TEXT    |
+    // FOLLOWUPID        | INTEGER |
+    // TOTRANSAMOUNT     | NUMERIC |
+    // COLOR             | INTEGER | DEFAULT -1
+
     // table columns
     static let col_id                = SQLite.Expression<Int64>("TRANSID")
     static let col_accountId         = SQLite.Expression<Int64>("ACCOUNTID")
@@ -109,17 +128,17 @@ extension TransactionRepository {
     }
 
     // insert query
-    static func insertQuery(_ txn: Transaction) -> Insert {
+    static func insertQuery(_ txn: Transaction) -> SQLite.Insert {
         return table.insert(insertSetters(txn))
     }
 
     // update query
-    static func updateQuery(_ txn: Transaction) -> Update {
+    static func updateQuery(_ txn: Transaction) -> SQLite.Update {
         return table.filter(col_id == txn.id).update(insertSetters(txn))
     }
 
     // delete query
-    static func deleteQuery(_ txn: Transaction) -> Delete {
+    static func deleteQuery(_ txn: Transaction) -> SQLite.Delete {
         return table.filter(col_id == txn.id).delete()
     }
 }


### PR DESCRIPTION
Changes:

- Move comments for DB fields from Models to Repositories. Models don't need to expose all DB details. They may contain less information, or more information (like Full_Data in MMEX Desktop), as needed by the application. On the other hand, Repositories represent the DB scheme in all possible details.

- Refactor Infotable (move DB access to InfotableRepository).

- Add `SQLite.` prefix in front of `Insert`, `Update`, `Delete`.