### PR TITLE
fix enum

### DIFF
--- a/MMEX/Models/Account.swift
+++ b/MMEX/Models/Account.swift
@@ -11,6 +11,7 @@ import SQLite
 enum AccountStatus: String, EnumCollateNoCase {
     case open   = "Open"
     case closed = "Closed"
+    static let defaultValue = Self.closed
 }
 
 enum AccountType: String, EnumCollateNoCase {
@@ -22,6 +23,7 @@ enum AccountType: String, EnumCollateNoCase {
     case investment = "Investment"
     case asset      = "Asset"
     case shares     = "Shares"
+    static let defaultValue = Self.checking
 }
 
 struct AccountData: ExportableEntity {
@@ -50,9 +52,9 @@ struct AccountData: ExportableEntity {
     init(
         id              : Int64         = 0,
         name            : String        = "",
-        type            : AccountType   = AccountType.checking,
+        type            : AccountType   = AccountType.defaultValue,
         num             : String        = "",
-        status          : AccountStatus = AccountStatus.closed,
+        status          : AccountStatus = AccountStatus.defaultValue,
         notes           : String        = "",
         heldAt          : String        = "",
         website         : String        = "",

--- a/MMEX/Models/Asset.swift
+++ b/MMEX/Models/Asset.swift
@@ -16,22 +16,26 @@ enum AssetType: String, EnumCollateNoCase {
     case jewellery  = "Jewellery"
     case cash       = "Cash"
     case other      = "Other"
+    static let defaultValue = Self.property
 }
 
 enum AssetStatus: String, EnumCollateNoCase {
     case closed = "Closed"
     case open   = "Open"
+    static let defaultValue = Self.open
 }
 
 enum AssetChange: String, EnumCollateNoCase {
     case none        = "None"
     case appreciates = "Appreciates"
     case depreciates = "Depreciates"
+    static let defaultValue = Self.none
 }
 
 enum AssetChangeMode: String, EnumCollateNoCase {
     case percentage = "Percentage"
     case linear     = "Linear"
+    static let defaultValue = Self.percentage
 }
 
 struct AssetData: ExportableEntity {
@@ -49,14 +53,14 @@ struct AssetData: ExportableEntity {
 
     init(
         id         : Int64            = 0,
-        type       : AssetType        = AssetType.property,
-        status     : AssetStatus      = AssetStatus.open,
+        type       : AssetType        = AssetType.defaultValue,
+        status     : AssetStatus      = AssetStatus.defaultValue,
         name       : String           = "",
         startDate  : String           = "",
         currencyId : Int64            = 0,
         value      : Double           = 0.0,
-        change     : AssetChange      = AssetChange.none,
-        changeMode : AssetChangeMode  = AssetChangeMode.percentage,
+        change     : AssetChange      = AssetChange.defaultValue,
+        changeMode : AssetChangeMode  = AssetChangeMode.defaultValue,
         changeRate : Double           = 0.0,
         notes      : String           = ""
     ) {

--- a/MMEX/Models/Scheduled.swift
+++ b/MMEX/Models/Scheduled.swift
@@ -12,6 +12,7 @@ enum RepeatAuto: Int, CaseIterable, Identifiable, Codable {
     case none = 0
     case manual
     case silent
+    static let defaultValue = Self.none
 
     static let names = [
         "None",
@@ -40,6 +41,7 @@ enum RepeatType: Int, CaseIterable, Identifiable, Codable {
     case everyXMonths
     case monthlyLastDay
     case monthlyLastBusinessDay
+    static let defaultValue = Self.once
 
     static let names = [
         "Once",
@@ -69,7 +71,7 @@ struct ScheduledData: ExportableEntity {
     var accountId         : Int64
     var toAccountId       : Int64
     var payeeId           : Int64
-    var transCode         : Transcode
+    var transCode         : TransactionType
     var transAmount       : Double
     var status            : TransactionStatus
     var transactionNumber : String
@@ -89,9 +91,9 @@ struct ScheduledData: ExportableEntity {
         accountId         : Int64             = 0,
         toAccountId       : Int64             = 0,
         payeeId           : Int64             = 0,
-        transCode         : Transcode         = Transcode.withdrawal,
+        transCode         : TransactionType   = TransactionType.defaultValue,
         transAmount       : Double            = 0.0,
-        status            : TransactionStatus = TransactionStatus.none,
+        status            : TransactionStatus = TransactionStatus.defaultValue,
         transactionNumber : String            = "",
         notes             : String            = "",
         categId           : Int64             = 0,
@@ -99,8 +101,8 @@ struct ScheduledData: ExportableEntity {
         followUpId        : Int64             = 0,
         toTransAmount     : Double            = 0.0,
         dueDate           : String            = "",
-        repeatAuto        : RepeatAuto        = RepeatAuto.none,
-        repeatType        : RepeatType        = RepeatType.once,
+        repeatAuto        : RepeatAuto        = RepeatAuto.defaultValue,
+        repeatType        : RepeatType        = RepeatType.defaultValue,
         repeatNum         : Int               = 0,
         color             : Int64             = 0
     ) {
@@ -148,17 +150,17 @@ struct ScheduledFull: FullProtocol {
 extension ScheduledData {
     static let sampleData : [ScheduledData] = [
         ScheduledData(
-            id: 1, accountId: 1, payeeId: 1, transCode: Transcode.withdrawal,
+            id: 1, accountId: 1, payeeId: 1, transCode: TransactionType.withdrawal,
             transAmount: 10.01, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),
         ScheduledData(
-            id: 2, accountId: 2, payeeId: 2, transCode: Transcode.deposit,
+            id: 2, accountId: 2, payeeId: 2, transCode: TransactionType.deposit,
             transAmount: 20.02, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),
         ScheduledData(
-            id: 3, accountId: 3, payeeId: 3, transCode: Transcode.transfer,
+            id: 3, accountId: 3, payeeId: 3, transCode: TransactionType.transfer,
             transAmount: 30.03, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),

--- a/MMEX/Models/Transaction.swift
+++ b/MMEX/Models/Transaction.swift
@@ -8,22 +8,22 @@
 import SQLite
 import Foundation
 
-enum Transcode: String, EnumCollateNoCase {
+enum TransactionType: String, EnumCollateNoCase {
     case withdrawal = "Withdrawal"
     case deposit    = "Deposit"
     case transfer   = "Transfer"
+    static let defaultValue = Self.withdrawal
 }
 
-enum TransactionStatus: String, CaseIterable, Identifiable, Codable {
+enum TransactionStatus: String, EnumCollateNoCase {
     // TODO: MMEX Desktop defines "" for none
     case none       = "N" // None
     case reconciled = "R" // Reconciled
     case void       = "V" // Void
     case followUp   = "F" // Follow up
     case duplicate  = "D" // Duplicate
-    
-    var id: String { self.rawValue }
-    var name: String { rawValue.capitalized }
+    static let defaultValue = Self.none
+
     var fullName: String {
         return switch self {
         // TODO: MMEX Desktop defines "Unreconciled" for none
@@ -34,6 +34,19 @@ enum TransactionStatus: String, CaseIterable, Identifiable, Codable {
         case .duplicate  : "Duplicate"
         }
     }
+
+    init(collateNoCase name: String?) {
+        guard let name else { self = Self.defaultValue; return }
+        for x in Self.allCases {
+            if x.rawValue.caseInsensitiveCompare(name) == .orderedSame ||
+                x.fullName.caseInsensitiveCompare(name) == .orderedSame
+            {
+                self = x
+                return
+            }
+        }
+        self = Self.defaultValue
+    }
 }
 
 struct TransactionData: ExportableEntity {
@@ -41,7 +54,7 @@ struct TransactionData: ExportableEntity {
     var accountId         : Int64
     var toAccountId       : Int64
     var payeeId           : Int64
-    var transCode         : Transcode
+    var transCode         : TransactionType
     var transAmount       : Double
     var status            : TransactionStatus
     var transactionNumber : String
@@ -59,9 +72,9 @@ struct TransactionData: ExportableEntity {
         accountId         : Int64             = 0,
         toAccountId       : Int64             = 0,
         payeeId           : Int64             = 0,
-        transCode         : Transcode         = Transcode.withdrawal,
+        transCode         : TransactionType   = TransactionType.defaultValue,
         transAmount       : Double            = 0.0,
-        status            : TransactionStatus = TransactionStatus.none,
+        status            : TransactionStatus = TransactionStatus.defaultValue,
         transactionNumber : String            = "",
         notes             : String            = "",
         categId           : Int64             = 0,
@@ -130,17 +143,17 @@ extension TransactionData {
 extension TransactionData {
     static let sampleData : [TransactionData] = [
         TransactionData(
-            id: 1, accountId: 1, payeeId: 1, transCode: Transcode.withdrawal,
+            id: 1, accountId: 1, payeeId: 1, transCode: TransactionType.withdrawal,
             transAmount: 10.01, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),
         TransactionData(
-            id: 2, accountId: 2, payeeId: 2, transCode: Transcode.deposit,
+            id: 2, accountId: 2, payeeId: 2, transCode: TransactionType.deposit,
             transAmount: 20.02, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),
         TransactionData(
-            id: 3, accountId: 3, payeeId: 3, transCode: Transcode.transfer,
+            id: 3, accountId: 3, payeeId: 3, transCode: TransactionType.transfer,
             transAmount: 30.03, status: TransactionStatus.none, categId: 1,
             transDate: Date().ISO8601Format()
         ),

--- a/MMEX/Protocols/EnumCollateNoCase.swift
+++ b/MMEX/Protocols/EnumCollateNoCase.swift
@@ -10,19 +10,17 @@ import Foundation
 protocol EnumCollateNoCase: RawRepresentable, CaseIterable, Identifiable, Codable
     where RawValue == String
 {
-    init?(collateNoCase name: String?)
-    var id: String { get }
-    var name: String { get }
+    static var defaultValue: Self { get }
 }
 
 extension EnumCollateNoCase {
-    init?(collateNoCase name: String?) {
-        guard let name else { return nil }
+    init(collateNoCase name: String?) {
+        guard let name else { self = Self.defaultValue; return }
         switch Self.allCases.first(where: {
             $0.rawValue.caseInsensitiveCompare(name) == .orderedSame
         } ) {
         case .some(let x): self = x
-        case .none: return nil
+        default: self = Self.defaultValue
         }
     }
 

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -105,9 +105,9 @@ class AccountRepository: RepositoryProtocol {
         return AccountData(
             id              : row[col_id],
             name            : row[col_name],
-            type            : AccountType(collateNoCase: row[col_type]) ?? AccountType.checking,
+            type            : AccountType(collateNoCase: row[col_type]),
             num             : row[col_num] ?? "",
-            status          : AccountStatus(collateNoCase: row[col_status]) ?? AccountStatus.closed,
+            status          : AccountStatus(collateNoCase: row[col_status]),
             notes           : row[col_notes] ?? "",
             heldAt          : row[col_heldAt] ?? "",
             website         : row[col_website] ?? "",

--- a/MMEX/Repositories/AssetRepository.swift
+++ b/MMEX/Repositories/AssetRepository.swift
@@ -70,14 +70,14 @@ class AssetRepository: RepositoryProtocol {
     static func selectData(_ row: SQLite.Row) -> AssetData {
         return AssetData(
             id         : row[col_id],
-            type       : AssetType(collateNoCase: row[col_type]) ?? AssetType.property,
-            status     : AssetStatus(collateNoCase: row[col_status]) ?? AssetStatus.open,
+            type       : AssetType(collateNoCase: row[col_type]),
+            status     : AssetStatus(collateNoCase: row[col_status]),
             name       : row[col_name],
             startDate  : row[col_startDate],
             currencyId : row[col_currencyId] ?? 0,
             value      : row[cast_value] ?? 0.0,
-            change     : AssetChange(collateNoCase: row[col_change]) ?? AssetChange.none,
-            changeMode : AssetChangeMode(collateNoCase: row[col_changeMode]) ?? AssetChangeMode.percentage,
+            change     : AssetChange(collateNoCase: row[col_change]),
+            changeMode : AssetChangeMode(collateNoCase: row[col_changeMode]),
             changeRate : row[cast_changeRate] ?? 0.0,
             notes      : row[col_notes] ?? ""
         )

--- a/MMEX/Repositories/ScheduledRepository.swift
+++ b/MMEX/Repositories/ScheduledRepository.swift
@@ -99,10 +99,10 @@ class ScheduledRepository: RepositoryProtocol {
           accountId         : row[col_accountId],
           toAccountId       : row[col_toAccountId] ?? 0,
           payeeId           : row[col_payeeId],
-          transCode         : Transcode(collateNoCase: row[col_transCode]) ?? Transcode.withdrawal,
+          transCode         : TransactionType(collateNoCase: row[col_transCode]),
           transAmount       : row[cast_transAmount],
           // TODO: case insersitive, convert either key or value
-          status            : TransactionStatus(rawValue: row[col_status] ?? "") ?? TransactionStatus.none,
+          status            : TransactionStatus(collateNoCase: row[col_status]),
           transactionNumber : row[col_transactionNumber] ?? "",
           notes             : row[col_notes] ?? "",
           categId           : row[col_categId] ?? 0,
@@ -110,8 +110,8 @@ class ScheduledRepository: RepositoryProtocol {
           followUpId        : row[col_followUpId] ?? 0,
           toTransAmount     : row[cast_toTransAmount] ?? 0.0,
           dueDate           : row[col_nextOccurrenceDate] ?? "",
-          repeatAuto        : RepeatAuto(rawValue: Int(row[col_repeats] ?? 0) / repeatBase) ?? RepeatAuto.none,
-          repeatType        : RepeatType(rawValue: Int(row[col_repeats] ?? 0) % repeatBase) ?? RepeatType.once,
+          repeatAuto        : RepeatAuto(rawValue: Int(row[col_repeats] ?? 0) / repeatBase) ?? RepeatAuto.defaultValue,
+          repeatType        : RepeatType(rawValue: Int(row[col_repeats] ?? 0) % repeatBase) ?? RepeatType.defaultValue,
           repeatNum         : Int(row[col_numOccurrences] ?? 0),
           color             : row[col_color] ?? 0
         )

--- a/MMEX/Repositories/TransactionRepository.swift
+++ b/MMEX/Repositories/TransactionRepository.swift
@@ -88,10 +88,10 @@ class TransactionRepository: RepositoryProtocol {
           accountId         : row[col_accountId],
           toAccountId       : row[col_toAccountId] ?? 0,
           payeeId           : row[col_payeeId],
-          transCode         : Transcode(collateNoCase: row[col_transCode]) ?? Transcode.withdrawal,
+          transCode         : TransactionType(collateNoCase: row[col_transCode]),
           transAmount       : row[cast_transAmount],
           // TODO: case insersitive, convert either key or value
-          status            : TransactionStatus(rawValue: row[col_status] ?? "") ?? TransactionStatus.none,
+          status            : TransactionStatus(collateNoCase: row[col_status]),
           transactionNumber : row[col_transactionNumber] ?? "",
           notes             : row[col_notes] ?? "",
           categId           : row[col_categId] ?? 0,
@@ -118,7 +118,7 @@ class TransactionRepository: RepositoryProtocol {
             col_payeeId           <- txn.payeeId,
             col_transCode         <- txn.transCode.id,
             col_transAmount       <- txn.transAmount,
-            col_status            <- txn.status.id,
+            col_status            <- txn.status.id,  // TODO: MMEX Desktop writes '' for .none
             col_transactionNumber <- txn.transactionNumber,
             col_notes             <- txn.notes,
             col_categId           <- txn.categId,

--- a/MMEX/Views/Settings/SettingsView.swift
+++ b/MMEX/Views/Settings/SettingsView.swift
@@ -11,7 +11,7 @@ struct SettingsView: View {
     let databaseURL: URL
     
     @AppStorage("defaultPayeeSetting") private var defaultPayeeSetting: DefaultPayeeSetting = .none
-    @AppStorage("defaultStatus") private var defaultStatus: TransactionStatus = .none
+    @AppStorage("defaultStatus") private var defaultStatus = TransactionStatus.defaultValue
 
     @State private var currencies: [CurrencyData] = []
     @State private var accounts: [AccountFull] = []

--- a/MMEX/Views/Transactions/TransactionEditView.swift
+++ b/MMEX/Views/Transactions/TransactionEditView.swift
@@ -18,7 +18,7 @@ struct TransactionEditView: View {
     
     // app level setting
     @AppStorage("defaultPayeeSetting") private var defaultPayeeSetting: DefaultPayeeSetting = .none
-    @AppStorage("defaultStatus") private var defaultStatus: TransactionStatus = .none
+    @AppStorage("defaultStatus") private var defaultStatus = TransactionStatus.defaultValue
 
     // Focus state for the Amount input to control keyboard focus
     @FocusState private var isAmountFocused: Bool
@@ -28,7 +28,7 @@ struct TransactionEditView: View {
             // 1. Transaction type picker (Deposit/Withdrawal/Transfer)
             HStack {
                 Picker("", selection: $txn.transCode) {
-                    ForEach(Transcode.allCases) { transCode in
+                    ForEach(TransactionType.allCases) { transCode in
                         Text(transCode.name).tag(transCode)
                     }
                 }

--- a/MMEX/Views/Transactions/TransactionListView2.swift
+++ b/MMEX/Views/Transactions/TransactionListView2.swift
@@ -73,13 +73,13 @@ struct TransactionListView2: View {
                                         Text(currency.format(amount: txn.transAmount))
                                             .frame(alignment: .trailing) // Ensure it's aligned to the right
                                             .font(.system(size: 16, weight: .bold))
-                                            .foregroundColor(txn.transCode == Transcode.deposit ? .green : .red) // Positive/negative amount color
+                                            .foregroundColor(txn.transCode == TransactionType.deposit ? .green : .red) // Positive/negative amount color
                                     } else {
                                         // Right column (Transaction Amount)
                                         Text(String(format: "%.2f", txn.transAmount))
                                             .frame(alignment: .trailing) // Ensure it's aligned to the right
                                             .font(.system(size: 16, weight: .bold))
-                                            .foregroundColor(txn.transCode == Transcode.deposit ? .green : .red) // Positive/negative amount color
+                                            .foregroundColor(txn.transCode == TransactionType.deposit ? .green : .red) // Positive/negative amount color
                                     }
                                 }
                             }


### PR DESCRIPTION
## Problems

- All enums have a default value, which is scattered in different places. Better to make it visible in the definition of each enum.

- The conversion from String to `TransactionStatus` is inconsistent with MMEX Desktop.

## Changes

- In `EnumCollateNoCase`, add `defaultValue` and change `init?` to `init`.

- In `RepeatAuto`, `RepeatType`, add `defaultValue`.

- Move the default values to the definition of each enum.

- Rename `Transcode` -> `TransactionType`.

- The conversion from String to `TransactionStatus` finds the case for which either the full name or the short name is (case-insensitive) equal to the string, or returns `none` is no match is found. Examples:
  - case-insinsitive `R` or `Reconciled` is converted to `.reconciled`
  - case-insensitive `N`, `U`, or empty string is converted to `.none`
  - case-insensitive `None` or `Unreconciled` is converted to `.none`
 
There is still an inconsistency: MMEX iOS stores `N` for `.none`, while MMEX Desktop stores empty string.
