### PR TITLE
Cache currency formats in DataManager

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -294,11 +294,11 @@
 		A39B1B3B2C9A66CB003E5562 /* Transactions */ = {
 			isa = PBXGroup;
 			children = (
-				A3C142A52C90417700D3CEC0 /* TransactionAddView2.swift */,
-				A3C1429D2C8FFCF100D3CEC0 /* TransactionAddView.swift */,
 				A3C142972C8FE62200D3CEC0 /* TransactionListView.swift */,
 				A3C142A92C90721800D3CEC0 /* TransactionListView2.swift */,
 				A3C142992C8FF77D00D3CEC0 /* TransactionDetailView.swift */,
+				A3C1429D2C8FFCF100D3CEC0 /* TransactionAddView.swift */,
+				A3C142A52C90417700D3CEC0 /* TransactionAddView2.swift */,
 				A3C142AB2C909C1C00D3CEC0 /* TransactionEditView.swift */,
 			);
 			path = Transactions;

--- a/MMEX/ContentView.swift
+++ b/MMEX/ContentView.swift
@@ -19,7 +19,8 @@ struct ContentView: View {
     @EnvironmentObject var dataManager: DataManager
 
     var body: some View {
-        ZStack {
+        print("DEBUG: ContentView.body")
+        return ZStack {
             if dataManager.isDatabaseConnected {
                 connectedView
             } else {
@@ -45,7 +46,12 @@ struct ContentView: View {
                 NavigationSplitView {
                     SidebarView(selectedTab: $selectedTab)
                 } detail: {
-                    TabContentView(selectedTab: $selectedTab, isDocumentPickerPresented: $isDocumentPickerPresented, isNewDocumentPickerPresented: $isNewDocumentPickerPresented, isSampleDocument: $isSampleDocument)
+                    TabContentView(
+                        selectedTab: $selectedTab,
+                        isDocumentPickerPresented: $isDocumentPickerPresented,
+                        isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
+                        isSampleDocument: $isSampleDocument
+                    )
                 }
             } else {
                 let infotableViewModel = InfotableViewModel(dataManager: dataManager)
@@ -140,8 +146,12 @@ struct ContentView: View {
     // Management tab
     private var managementTab: some View {
         NavigationView {
-            ManagementView(isDocumentPickerPresented: $isDocumentPickerPresented, isNewDocumentPickerPresented: $isNewDocumentPickerPresented, isSampleDocument: $isSampleDocument)
-                .navigationBarTitle("Management", displayMode: .inline)
+            ManagementView(
+                isDocumentPickerPresented: $isDocumentPickerPresented,
+                isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
+                isSampleDocument: $isSampleDocument
+            )
+            .navigationBarTitle("Management", displayMode: .inline)
         }
         .tabItem {
             Image(systemName: "folder")
@@ -231,10 +241,11 @@ struct TabContentView: View {
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
 
     var body: some View {
+        print("DEBUG: TabContentView.body")
         // Use @StateObject to manage the lifecycle of InfotableViewModel
         let infotableViewModel = InfotableViewModel(dataManager: dataManager)
         // Here we ensure that there's no additional NavigationStack or NavigationView
-        Group {
+        return Group {
             switch selectedTab {
             case 0:
                 TransactionListView2(viewModel: infotableViewModel) // Summary and Edit feature
@@ -246,8 +257,12 @@ struct TabContentView: View {
                 TransactionAddView2(selectedTab: $selectedTab)
                     .navigationBarTitle("Add Transaction", displayMode: .inline)
             case 3:
-                ManagementView(isDocumentPickerPresented: $isDocumentPickerPresented, isNewDocumentPickerPresented: $isNewDocumentPickerPresented, isSampleDocument: $isSampleDocument)
-                    .navigationBarTitle("Management", displayMode: .inline)
+                ManagementView(
+                    isDocumentPickerPresented: $isDocumentPickerPresented,
+                    isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
+                    isSampleDocument: $isSampleDocument
+                )
+                .navigationBarTitle("Management", displayMode: .inline)
             case 4:
                 SettingsView(viewModel: infotableViewModel)
                     .navigationBarTitle("Settings", displayMode: .inline)

--- a/MMEX/DatabaseManager.swift
+++ b/MMEX/DatabaseManager.swift
@@ -121,15 +121,8 @@ extension DataManager {
         currencyFormat = CurrencyRepository(db)?.dictionaryRefFormat() ?? [:]
     }
 
-    func updateCurrencyFormat(id: Int64, format: CurrencyFormatProtocol) {
-        currencyFormat[id] = CurrencyFormat(
-            prefixSymbol   : format.prefixSymbol,
-            suffixSymbol   : format.suffixSymbol,
-            decimalPoint   : format.decimalPoint,
-            groupSeparator : format.groupSeparator,
-            scale          : format.scale,
-            baseConvRate   : format.baseConvRate
-        )
+    func updateCurrencyFormat(id: Int64, value: CurrencyFormat) {
+        currencyFormat[id] = value
     }
 }
 

--- a/MMEX/DatabaseManager.swift
+++ b/MMEX/DatabaseManager.swift
@@ -12,14 +12,16 @@ class DataManager: ObservableObject {
     @Published var isDatabaseConnected = false
     private(set) var db: Connection?
     private(set) var databaseURL: URL?
-    
+
+    var currencyFormat: [Int64: CurrencyFormat] = [:]
+
     init() {
         connectToStoredDatabase()
     }
 }
 
 extension DataManager {
-    func openDatabase(at url: URL) {
+    func openDatabase(at url: URL, isNew: Bool = false) {
         if url.startAccessingSecurityScopedResource() {
             defer { url.stopAccessingSecurityScopedResource() }
             do {
@@ -42,6 +44,10 @@ extension DataManager {
             isDatabaseConnected = false
             databaseURL = nil
         }
+
+        if !isNew {
+            loadCurrencyFormat()
+        }
     }
 
     /// Method to connect to a previously stored database path if available
@@ -55,7 +61,7 @@ extension DataManager {
     }
 
     func createDatabase(at url: URL, sampleData: Bool) {
-        openDatabase(at: url)
+        openDatabase(at: url, isNew: true)
         guard let db else { return }
 
         guard let tables = Bundle.main.url(forResource: "tables.sql", withExtension: "") else {
@@ -86,6 +92,7 @@ extension DataManager {
                 return
             }
         }
+        loadCurrencyFormat()
     }
 
     /// Closes the current database connection and resets related states.
@@ -94,6 +101,7 @@ extension DataManager {
         isDatabaseConnected = false
         db = nil
         databaseURL = nil
+        currencyFormat = [:]
         print("Database connection closed.")
     }
 }
@@ -105,6 +113,23 @@ extension DataManager {
         if let cacheDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?.path {
             _ = Repository(db).setPragma(name: "temp_store_directory", value: "'\(cacheDir)'")
         }
+    }
+}
+
+extension DataManager {
+    func loadCurrencyFormat() {
+        currencyFormat = CurrencyRepository(db)?.dictionaryRefFormat() ?? [:]
+    }
+
+    func updateCurrencyFormat(id: Int64, format: CurrencyFormatProtocol) {
+        currencyFormat[id] = CurrencyFormat(
+            prefixSymbol   : format.prefixSymbol,
+            suffixSymbol   : format.suffixSymbol,
+            decimalPoint   : format.decimalPoint,
+            groupSeparator : format.groupSeparator,
+            scale          : format.scale,
+            baseConvRate   : format.baseConvRate
+        )
     }
 }
 

--- a/MMEX/Models/AccountData.swift
+++ b/MMEX/Models/AccountData.swift
@@ -99,29 +99,3 @@ extension AccountData {
         ),
     ]
 }
-
-// TODO: move to ViewModels
-struct AccountWithCurrency: ExportableEntity {
-    var data: AccountData = AccountData()
-    var currency: CurrencyData?
-    var id: Int64 { data.id }
-}
-extension AccountData {
-    static let sampleDataWithCurrency : [AccountWithCurrency] = [
-        AccountWithCurrency(data: AccountData(
-            id: 1, name: "Cash Account", type: AccountType.cash,
-            status: AccountStatus.open, notes:"",
-            initialBal: 100.01, favoriteAcct: "TRUE", currencyId: 1
-        ), currency: CurrencyData.sampleData[0]),
-        AccountWithCurrency(data: AccountData(
-            id: 2, name: "Chcking Account", type: AccountType.checking,
-            status: AccountStatus.open, notes:"",
-            initialBal: 200.02, favoriteAcct: "TRUE", currencyId: 2
-        ), currency: CurrencyData.sampleData[1]),
-        AccountWithCurrency(data: AccountData(
-            id: 3, name: "Investment Account", type: AccountType.investment,
-            status: AccountStatus.open, notes:"",
-            initialBal: 300.03, favoriteAcct: "TRUE", currencyId: 2
-        ), currency: CurrencyData.sampleData[1]),
-    ]
-}

--- a/MMEX/Models/CurrencyData.swift
+++ b/MMEX/Models/CurrencyData.swift
@@ -38,6 +38,7 @@ extension CurrencyData: DataProtocol {
 }
 
 protocol CurrencyFormatProtocol {
+    var name           : String { get }
     var prefixSymbol   : String { get }
     var suffixSymbol   : String { get }
     var decimalPoint   : String { get }
@@ -47,6 +48,7 @@ protocol CurrencyFormatProtocol {
 }
 
 struct CurrencyFormat: CurrencyFormatProtocol {
+    let name           : String
     let prefixSymbol   : String
     let suffixSymbol   : String
     let decimalPoint   : String
@@ -57,6 +59,7 @@ struct CurrencyFormat: CurrencyFormatProtocol {
 
 extension CurrencyFormatProtocol {
     var toCurrencyFormat: CurrencyFormat { CurrencyFormat(
+        name           : self.name,
         prefixSymbol   : self.prefixSymbol,
         suffixSymbol   : self.suffixSymbol,
         decimalPoint   : self.decimalPoint,

--- a/MMEX/Models/CurrencyData.swift
+++ b/MMEX/Models/CurrencyData.swift
@@ -31,7 +31,28 @@ extension CurrencyData: DataProtocol {
     }
 }
 
-extension CurrencyData {
+protocol CurrencyFormatProtocol {
+    var prefixSymbol   : String { get }
+    var suffixSymbol   : String { get }
+    var decimalPoint   : String { get }
+    var groupSeparator : String { get }
+    var scale          : Int    { get }
+    var baseConvRate   : Double { get }
+}
+
+struct CurrencyFormat: CurrencyFormatProtocol {
+    let prefixSymbol   : String
+    let suffixSymbol   : String
+    let decimalPoint   : String
+    let groupSeparator : String
+    let scale          : Int
+    let baseConvRate   : Double
+}
+
+extension CurrencyData: CurrencyFormatProtocol {
+}
+
+extension CurrencyFormatProtocol {
     /// A `NumberFormatter` configured specifically for the currency.
     var formatter: NumberFormatter {
         let nf = NumberFormatter()
@@ -54,6 +75,7 @@ extension CurrencyData {
         }
     }
 
+    // TODO: move to higher level where base currency is maintained
     /// Helper method to convert and format the amount into base currency using the exchange rate.
     func formatAsBaseCurrency(amount: Double, baseCurrencyRate: Double?) -> String {
         let baseAmount = amount * (baseCurrencyRate ?? self.baseConvRate)

--- a/MMEX/Models/CurrencyData.swift
+++ b/MMEX/Models/CurrencyData.swift
@@ -8,19 +8,25 @@
 import Foundation
 import SQLite
 
+enum CurrencyType: String, EnumCollateNoCase {
+    case fiat   = "Fiat"
+    case crypto = "Crypto"
+    static let defaultValue = Self.fiat
+}
+
 struct CurrencyData: ExportableEntity, CurrencyFormatProtocol {
-    var id             : Int64  = 0
-    var name           : String = ""
-    var prefixSymbol   : String = ""
-    var suffixSymbol   : String = ""
-    var decimalPoint   : String = ""
-    var groupSeparator : String = ""
-    var unitName       : String = ""
-    var centName       : String = ""
-    var scale          : Int    = 0
-    var baseConvRate   : Double = 0.0
-    var symbol         : String = ""
-    var type           : String = ""
+    var id             : Int64        = 0
+    var name           : String       = ""
+    var prefixSymbol   : String       = ""
+    var suffixSymbol   : String       = ""
+    var decimalPoint   : String       = ""
+    var groupSeparator : String       = ""
+    var unitName       : String       = ""
+    var centName       : String       = ""
+    var scale          : Int          = 0
+    var baseConvRate   : Double       = 0.0
+    var symbol         : String       = ""
+    var type           : CurrencyType = CurrencyType.defaultValue
 }
 
 extension CurrencyData: DataProtocol {
@@ -97,17 +103,17 @@ extension CurrencyData {
         CurrencyData(
             id: 1, name: "US dollar", prefixSymbol: "$", suffixSymbol: "",
             decimalPoint: ".", groupSeparator: ",", unitName: "Dollar", centName: "Cent",
-            scale: 100, baseConvRate: 1.0, symbol: "USD", type: "Fiat"
+            scale: 100, baseConvRate: 1.0, symbol: "USD", type: .fiat
         ),
         CurrencyData(
             id: 2, name: "Euro", prefixSymbol: "€", suffixSymbol: "",
             decimalPoint: ".", groupSeparator: " ", unitName: "", centName: "",
-            scale: 100, baseConvRate: 1.0, symbol: "EUR", type: "Fiat"
+            scale: 100, baseConvRate: 1.0, symbol: "EUR", type: .fiat
         ),
         CurrencyData(
             id: 3, name: "British pound", prefixSymbol: "£", suffixSymbol: "",
             decimalPoint: ".", groupSeparator: " ", unitName: "Pound", centName: "Pence",
-            scale: 100, baseConvRate: 1.0, symbol: "GBP", type: "Fiat"
+            scale: 100, baseConvRate: 1.0, symbol: "GBP", type: .fiat
         ),
     ]
 }

--- a/MMEX/Models/CurrencyData.swift
+++ b/MMEX/Models/CurrencyData.swift
@@ -37,6 +37,7 @@ extension CurrencyData: DataProtocol {
     }
 }
 
+// TODO: remove CurrencyFormat; use CurrencyData instead
 protocol CurrencyFormatProtocol {
     var name           : String { get }
     var prefixSymbol   : String { get }

--- a/MMEX/Models/CurrencyData.swift
+++ b/MMEX/Models/CurrencyData.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SQLite
 
-struct CurrencyData: ExportableEntity {
+struct CurrencyData: ExportableEntity, CurrencyFormatProtocol {
     var id             : Int64  = 0
     var name           : String = ""
     var prefixSymbol   : String = ""
@@ -49,7 +49,15 @@ struct CurrencyFormat: CurrencyFormatProtocol {
     let baseConvRate   : Double
 }
 
-extension CurrencyData: CurrencyFormatProtocol {
+extension CurrencyFormatProtocol {
+    var toCurrencyFormat: CurrencyFormat { CurrencyFormat(
+        prefixSymbol   : self.prefixSymbol,
+        suffixSymbol   : self.suffixSymbol,
+        decimalPoint   : self.decimalPoint,
+        groupSeparator : self.groupSeparator,
+        scale          : self.scale,
+        baseConvRate   : self.baseConvRate
+    ) }
 }
 
 extension CurrencyFormatProtocol {

--- a/MMEX/Models/Data.swift
+++ b/MMEX/Models/Data.swift
@@ -34,3 +34,8 @@ extension EnumCollateNoCase {
     var id: String { self.rawValue }
     var name: String { rawValue.capitalized }
 }
+
+struct IdName: Identifiable {
+    let id: Int64
+    let name: String
+}

--- a/MMEX/Models/Data.swift
+++ b/MMEX/Models/Data.swift
@@ -34,8 +34,3 @@ extension EnumCollateNoCase {
     var id: String { self.rawValue }
     var name: String { rawValue.capitalized }
 }
-
-struct IdName: Identifiable {
-    let id: Int64
-    let name: String
-}

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -175,8 +175,8 @@ extension AccountRepository {
     // load account of a stock
     func pluck(for stock: StockData) -> AccountData? {
         return pluck(
-            from: Self.table.filter(Self.col_id == stock.accountId),
-            key: "\(stock.accountId)"
+            key: "\(stock.accountId)",
+            from: Self.table.filter(Self.col_id == stock.accountId)
         )
     }
 }

--- a/MMEX/Repositories/AccountRepository.swift
+++ b/MMEX/Repositories/AccountRepository.swift
@@ -180,32 +180,3 @@ extension AccountRepository {
         )
     }
 }
-
-// TODO: move to ViewModels
-extension AccountRepository {
-    // load all accounts and their currency
-    func loadWithCurrency() -> [AccountWithCurrency] {
-        // TODO via join?
-        // Create a lookup dictionary for currencies by currencyId
-        let currencies = CurrencyRepository(db).load();
-        let currencyDict = Dictionary(uniqueKeysWithValues: currencies.map { ($0.id, $0) })
-
-        do {
-            var data: [AccountWithCurrency] = []
-            for row in try db.prepare(Self.selectData(from: Self.table
-                .order(Self.col_name)
-            )) {
-                let account = Self.fetchData(row)
-                data.append(AccountWithCurrency(
-                    data: account,
-                    currency: currencyDict[account.currencyId]
-                ) )
-            }
-            print("Successfull select from \(Self.repositoryName): \(data.count)")
-            return data
-        } catch {
-            print("Failed select from \(Self.repositoryName): \(error)")
-            return []
-        }
-    }
-}

--- a/MMEX/Repositories/AssetRepository.swift
+++ b/MMEX/Repositories/AssetRepository.swift
@@ -109,4 +109,13 @@ extension AssetRepository {
             .order(Self.col_type, Self.col_status.desc, Self.col_name)
         )
     }
+
+    // load currencyId for all accounts
+    func loadCurrencyId() -> [Int64] {
+        return Repository(db).select(from: Self.table
+            .select(distinct: Self.col_currencyId)
+        ) { row in
+            row[Self.col_currencyId] ?? 0
+        }
+    }
 }

--- a/MMEX/Repositories/CategoryRepository.swift
+++ b/MMEX/Repositories/CategoryRepository.swift
@@ -69,11 +69,11 @@ extension CategoryRepository {
         return select(from: Self.table)
     }
 
-    // load category of a payeer
+    // load category of a payee
     func pluck(for payee: PayeeData) -> CategoryData? {
         return pluck(
-            from: Self.table.filter(Self.col_id == payee.categoryId),
-            key: "\(payee.categoryId)"
+            key: "\(payee.categoryId)",
+            from: Self.table.filter(Self.col_id == payee.categoryId)
         )
     }
 }

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -160,6 +160,7 @@ extension CurrencyRepository {
         }
     }
 
+    // TODO: re-write in a more readable way (get the ids first, then pluck each currency)
     // load all referred currency formats, indexed by currencyId
     func dictionaryRefFormat() -> [Int64: CurrencyFormat] {
         print("DEBUG: CurrencyRepository.dictionaryRefFormat()")

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -108,6 +108,7 @@ struct CurrencyRepository: RepositoryProtocol {
     static func selectFormat(from table: SQLite.Table) -> SQLite.Table {
         return table.select(
             col_id,
+            col_name,
             col_prefixSymbol,
             col_suffixSymbol,
             col_decimalPoint,
@@ -119,6 +120,7 @@ struct CurrencyRepository: RepositoryProtocol {
 
     static func fetchFormat(_ row: SQLite.Row) -> CurrencyFormat {
         return CurrencyFormat(
+            name           : row[col_name],
             prefixSymbol   : row[col_prefixSymbol] ?? "",
             suffixSymbol   : row[col_suffixSymbol] ?? "",
             decimalPoint   : row[col_decimalPoint] ?? "",
@@ -166,6 +168,7 @@ extension CurrencyRepository {
         typealias E = AssetRepository
         let query = "select" +
         " \(C.col_id)," +
+        " \(C.col_name)," +
         " \(C.col_prefixSymbol)," +
         " \(C.col_suffixSymbol)," +
         " \(C.col_decimalPoint)," +
@@ -181,12 +184,13 @@ extension CurrencyRepository {
         return Repository(db).dictionary(
             query: query
         ) { row in CurrencyFormat(
-            prefixSymbol   : row[1] as? String ?? "",
-            suffixSymbol   : row[2] as? String ?? "",
-            decimalPoint   : row[3] as? String ?? "",
-            groupSeparator : row[4] as? String ?? "",
-            scale          : row[5] as? Int    ?? 0,
-            baseConvRate   : row[6] as? Double ?? 0.0
+            name           : row[1] as? String ?? "",
+            prefixSymbol   : row[2] as? String ?? "",
+            suffixSymbol   : row[3] as? String ?? "",
+            decimalPoint   : row[4] as? String ?? "",
+            groupSeparator : row[5] as? String ?? "",
+            scale          : row[6] as? Int    ?? 0,
+            baseConvRate   : row[7] as? Double ?? 0.0
         ) }
     }
 

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -85,7 +85,7 @@ struct CurrencyRepository: RepositoryProtocol {
             scale          : row[col_scale] ?? 0,
             baseConvRate   : row[cast_baseConvRate] ?? 0.0,
             symbol         : row[col_symbol],
-            type           : row[col_type]
+            type           : CurrencyType(collateNoCase: row[col_type])
         )
     }
 
@@ -101,7 +101,7 @@ struct CurrencyRepository: RepositoryProtocol {
             col_scale          <- data.scale,
             col_baseConvRate   <- data.baseConvRate,
             col_symbol         <- data.symbol,
-            col_type           <- data.type
+            col_type           <- data.type.rawValue
         ]
     }
     

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -39,21 +39,21 @@ struct CurrencyRepository: RepositoryProtocol {
     // CURRENCY_TYPE   | TEXT    | NOT NULL (Fiat, Crypto)
 
     // column expressions
-    static let col_id                 = SQLite.Expression<Int64>("CURRENCYID")
-    static let col_name               = SQLite.Expression<String>("CURRENCYNAME")
-    static let col_prefixSymbol       = SQLite.Expression<String?>("PFX_SYMBOL")
-    static let col_suffixSymbol       = SQLite.Expression<String?>("SFX_SYMBOL")
-    static let col_decimalPoint       = SQLite.Expression<String?>("DECIMAL_POINT")
-    static let col_groupSeparator     = SQLite.Expression<String?>("GROUP_SEPARATOR")
-    static let col_unitName           = SQLite.Expression<String?>("UNIT_NAME")
-    static let col_centName           = SQLite.Expression<String?>("CENT_NAME")
-    static let col_scale              = SQLite.Expression<Int?>("SCALE")
-    static let col_baseConversionRate = SQLite.Expression<Double?>("BASECONVRATE")
-    static let col_symbol             = SQLite.Expression<String>("CURRENCY_SYMBOL")
-    static let col_type               = SQLite.Expression<String>("CURRENCY_TYPE")
+    static let col_id             = SQLite.Expression<Int64>("CURRENCYID")
+    static let col_name           = SQLite.Expression<String>("CURRENCYNAME")
+    static let col_prefixSymbol   = SQLite.Expression<String?>("PFX_SYMBOL")
+    static let col_suffixSymbol   = SQLite.Expression<String?>("SFX_SYMBOL")
+    static let col_decimalPoint   = SQLite.Expression<String?>("DECIMAL_POINT")
+    static let col_groupSeparator = SQLite.Expression<String?>("GROUP_SEPARATOR")
+    static let col_unitName       = SQLite.Expression<String?>("UNIT_NAME")
+    static let col_centName       = SQLite.Expression<String?>("CENT_NAME")
+    static let col_scale          = SQLite.Expression<Int?>("SCALE")
+    static let col_baseConvRate   = SQLite.Expression<Double?>("BASECONVRATE")
+    static let col_symbol         = SQLite.Expression<String>("CURRENCY_SYMBOL")
+    static let col_type           = SQLite.Expression<String>("CURRENCY_TYPE")
 
     // cast NUMERIC to REAL
-    static let cast_baseConversionRate = cast(col_baseConversionRate) as SQLite.Expression<Double?>
+    static let cast_baseConvRate = cast(col_baseConvRate) as SQLite.Expression<Double?>
 
     static func selectData(from table: SQLite.Table) -> SQLite.Table {
         return table.select(
@@ -66,7 +66,7 @@ struct CurrencyRepository: RepositoryProtocol {
             col_unitName,
             col_centName,
             col_scale,
-            cast_baseConversionRate,
+            cast_baseConvRate,
             col_symbol,
             col_type
         )
@@ -83,7 +83,7 @@ struct CurrencyRepository: RepositoryProtocol {
             unitName       : row[col_unitName] ?? "",
             centName       : row[col_centName] ?? "",
             scale          : row[col_scale] ?? 0,
-            baseConvRate   : row[cast_baseConversionRate] ?? 0.0,
+            baseConvRate   : row[cast_baseConvRate] ?? 0.0,
             symbol         : row[col_symbol],
             type           : row[col_type]
         )
@@ -91,51 +91,98 @@ struct CurrencyRepository: RepositoryProtocol {
 
     static func itemSetters(_ data: CurrencyData) -> [SQLite.Setter] {
         return [
-            col_name               <- data.name,
-            col_prefixSymbol       <- data.prefixSymbol,
-            col_suffixSymbol       <- data.suffixSymbol,
-            col_decimalPoint       <- data.decimalPoint,
-            col_groupSeparator     <- data.groupSeparator,
-            col_unitName           <- data.unitName,
-            col_centName           <- data.centName,
-            col_scale              <- data.scale,
-            col_baseConversionRate <- data.baseConvRate,
-            col_symbol             <- data.symbol,
-            col_type               <- data.type
+            col_name           <- data.name,
+            col_prefixSymbol   <- data.prefixSymbol,
+            col_suffixSymbol   <- data.suffixSymbol,
+            col_decimalPoint   <- data.decimalPoint,
+            col_groupSeparator <- data.groupSeparator,
+            col_unitName       <- data.unitName,
+            col_centName       <- data.centName,
+            col_scale          <- data.scale,
+            col_baseConvRate   <- data.baseConvRate,
+            col_symbol         <- data.symbol,
+            col_type           <- data.type
         ]
+    }
+    
+    static func selectFormat(from table: SQLite.Table) -> SQLite.Table {
+        return table.select(
+            col_id,
+            col_prefixSymbol,
+            col_suffixSymbol,
+            col_decimalPoint,
+            col_groupSeparator,
+            col_scale,
+            cast_baseConvRate
+        )
+    }
+
+    static func fetchFormat(_ row: SQLite.Row) -> CurrencyFormat {
+        return CurrencyFormat(
+            prefixSymbol   : row[col_prefixSymbol] ?? "",
+            suffixSymbol   : row[col_suffixSymbol] ?? "",
+            decimalPoint   : row[col_decimalPoint] ?? "",
+            groupSeparator : row[col_groupSeparator] ?? "",
+            scale          : row[col_scale] ?? 0,
+            baseConvRate   : row[cast_baseConvRate] ?? 0.0
+        )
     }
 }
 
 extension CurrencyRepository {
-    // load all currencies
+    // load all currencies, sorted by name
     func load() -> [CurrencyData] {
+        print("DEBUG: CurrencyRepository.load()")
         return select(from: Self.table
             .order(Self.col_name)
         )
     }
 
-    // load currencies for all accounts
-    func dictForAccount() -> [Int64: CurrencyData] {
+    // load all referred currency formats, indexed by currencyId
+    func dictionaryRefFormat() -> [Int64: CurrencyFormat] {
+        print("DEBUG: CurrencyRepository.dictionaryRefFormat()")
+        typealias C = CurrencyRepository
         typealias A = AccountRepository
-        let a_currencyId = A.table.select(distinct: A.col_currencyId)
-        return dict(from: Self.table
-            .join(a_currencyId, on: a_currencyId[A.col_currencyId] == Self.col_id)
-        )
+        typealias E = AssetRepository
+        let query = "select" +
+        " \(C.col_id)," +
+        " \(C.col_prefixSymbol)," +
+        " \(C.col_suffixSymbol)," +
+        " \(C.col_decimalPoint)," +
+        " \(C.col_groupSeparator)," +
+        " \(C.col_scale)," +
+        " \(C.cast_baseConvRate)" +
+        " from \(C.repositoryName)" +
+        " where exists (" +
+        "select 1 from \(A.repositoryName) where \(A.table[A.col_currencyId]) == \(C.table[C.col_id])" +
+        " union " +
+        "select 1 from \(E.repositoryName) where \(E.table[E.col_currencyId]) == \(C.table[C.col_id])" +
+        ")"
+        return Repository(db).dictionary(
+            query: query
+        ) { row in CurrencyFormat(
+            prefixSymbol   : row[1] as? String ?? "",
+            suffixSymbol   : row[2] as? String ?? "",
+            decimalPoint   : row[3] as? String ?? "",
+            groupSeparator : row[4] as? String ?? "",
+            scale          : row[5] as? Int    ?? 0,
+            baseConvRate   : row[6] as? Double ?? 0.0
+        ) }
     }
 
     // load currency of an account
     func pluck(for account: AccountData) -> CurrencyData? {
         return pluck(
-            from: Self.table.filter(Self.col_id == account.currencyId),
-            key: "\(account.currencyId)"
+            key: "\(account.currencyId)",
+            from: Self.table.filter(Self.col_id == account.currencyId)
         )
     }
 
     // load currency of an asset
     func pluck(for asset: AssetData) -> CurrencyData? {
         return pluck(
-            from: Self.table.filter(Self.col_id == asset.currencyId),
-            key: "\(asset.currencyId)"
+            key: "\(asset.currencyId)",
+            from: Self.table.filter(Self.col_id == asset.currencyId)
         )
     }
 }

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -139,12 +139,22 @@ extension CurrencyRepository {
     }
 
     // load all currency names
-    func loadName() -> [IdName] {
+    func loadName() -> [(id: Int64, name: String)] {
         print("DEBUG: CurrencyRepository.loadName()")
         return select(from: Self.table
             .order(Self.col_name)
         ) { row in
-            IdName(id: row[Self.col_id], name: row[Self.col_name])
+            (id: row[Self.col_id], name: row[Self.col_name])
+        }
+    }
+
+    // load all currency symbols
+    func loadSymbol() -> [(Int64, String)] {
+        print("DEBUG: CurrencyRepository.loadName()")
+        return select(from: Self.table
+            .order(Self.col_symbol)
+        ) { row in
+            (id: row[Self.col_id], name: row[Self.col_symbol])
         }
     }
 

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -138,6 +138,16 @@ extension CurrencyRepository {
         )
     }
 
+    // load all currency names
+    func loadName() -> [IdName] {
+        print("DEBUG: CurrencyRepository.loadName()")
+        return select(from: Self.table
+            .order(Self.col_name)
+        ) { row in
+            IdName(id: row[Self.col_id], name: row[Self.col_name])
+        }
+    }
+
     // load all referred currency formats, indexed by currencyId
     func dictionaryRefFormat() -> [Int64: CurrencyFormat] {
         print("DEBUG: CurrencyRepository.dictionaryRefFormat()")

--- a/MMEX/Repositories/InfotableRepository.swift
+++ b/MMEX/Repositories/InfotableRepository.swift
@@ -68,10 +68,10 @@ extension InfotableRepository {
     func load(for keys: [InfoKey]) -> [InfoKey: InfotableData] {
         var results: [InfoKey: InfotableData] = [:]
         for key in keys {
-            if let info = pluck(
-                from: Self.table.filter(Self.col_name == key.rawValue),
-                key: key.rawValue
-            ) {
+            if let info: InfotableData = (pluck(
+                key: key.rawValue,
+                from: Self.table.filter(Self.col_name == key.rawValue)
+            )) {
                 results[key] = info
             }
         }
@@ -81,10 +81,10 @@ extension InfotableRepository {
     // New Methods for Key-Value Pairs
     // Fetch value for a specific key, allowing for String or Int64
     func getValue<T>(for key: String, as type: T.Type) -> T? {
-        if let info = pluck(
-            from: Self.table.filter(Self.col_name == key),
-            key: key
-        ) {
+        if let info: InfotableData = (pluck(
+            key: key,
+            from: Self.table.filter(Self.col_name == key)
+        )) {
             if type == String.self {
                 return info.value as? T
             } else if type == Int64.self {
@@ -106,10 +106,10 @@ extension InfotableRepository {
             return
         }
 
-        if var info = pluck(
-            from: Self.table.filter(Self.col_name == key),
-            key: key
-        ) {
+        if var info: InfotableData = (pluck(
+            key: key,
+            from: Self.table.filter(Self.col_name == key)
+        )) {
             // Update existing setting
             info.value = stringValue
             _ = update(info)

--- a/MMEX/Repositories/Repository.swift
+++ b/MMEX/Repositories/Repository.swift
@@ -53,6 +53,24 @@ extension Repository {
         }
     }
 
+    func dictionary<Result>(
+        query: String,
+        with result: (SQLite.Statement.Element) -> Result
+    ) -> [Int64: Result] {
+        print("DEBUG: Repository.dictionary: \(query)")
+        do {
+            var dict: [Int64: Result] = [:]
+            for row in try db.prepare(query) {
+                dict[row[0] as! Int64] = result(row)
+            }
+            print("Successfull dictionary: \(dict.count)")
+            return dict
+        } catch {
+            print("Failed dictionary: \(error)")
+            return [:]
+        }
+    }
+
     func execute(sql: String) -> Bool {
         print("Executing sql: \(sql)")
         do {

--- a/MMEX/ViewModels/InfotableViewModel.swift
+++ b/MMEX/ViewModels/InfotableViewModel.swift
@@ -26,7 +26,7 @@ class InfotableViewModel: ObservableObject {
     private var currencyRepo: CurrencyRepository?
 
     @Published var currencies: [CurrencyData] = []
-    @Published var accounts: [AccountWithCurrency] = []
+    @Published var accounts: [AccountData] = []
 
     @Published var txns: [TransactionData] = []
     @Published var txns_per_day: [String: [TransactionData]] = [:]
@@ -100,12 +100,12 @@ class InfotableViewModel: ObservableObject {
 
     func loadAccounts() {
         DispatchQueue.global(qos: .background).async {
-            let loadedAccounts = self.accountRepo?.loadWithCurrency() ?? []
+            let loadedAccounts = self.accountRepo?.load() ?? []
             DispatchQueue.main.async {
                 self.accounts = loadedAccounts
 
                 if (loadedAccounts.count == 1) {
-                    self.defaultAccountId = loadedAccounts.first!.data.id
+                    self.defaultAccountId = loadedAccounts.first!.id
                 }
             }
         }

--- a/MMEX/ViewModels/InfotableViewModel.swift
+++ b/MMEX/ViewModels/InfotableViewModel.swift
@@ -49,16 +49,16 @@ class InfotableViewModel: ObservableObject {
         if let baseCurrencyId = infotableRepo?.getValue(for: InfoKey.baseCurrencyID.id, as: Int64.self) {
             self.baseCurrencyId = baseCurrencyId
             baseCurrency = currencyRepo?.pluck(
-                from: CurrencyRepository.table.filter(CurrencyRepository.col_id == baseCurrencyId),
-                key: InfoKey.baseCurrencyID.id
+                key: InfoKey.baseCurrencyID.id,
+                from: CurrencyRepository.table.filter(CurrencyRepository.col_id == baseCurrencyId)
             )
         }
 
         if let defaultAccountId = infotableRepo?.getValue(for: InfoKey.defaultAccountID.id, as: Int64.self) {
             self.defaultAccountId = defaultAccountId
             defaultAccount = accountRepo?.pluck(
-                from: AccountRepository.table.filter(AccountRepository.col_id == defaultAccountId),
-                key: InfoKey.defaultAccountID.id
+                key: InfoKey.defaultAccountID.id,
+                from: AccountRepository.table.filter(AccountRepository.col_id == defaultAccountId)
             )
         }
     }

--- a/MMEX/ViewModels/InfotableViewModel.swift
+++ b/MMEX/ViewModels/InfotableViewModel.swift
@@ -73,7 +73,7 @@ class InfotableViewModel: ObservableObject {
     private func setupBindings() {
         // Bind for defaultAccountId, using dropFirst to ignore initial assignment
         $defaultAccountId
-            .dropFirst() // Ignore the first emitted value
+            //.dropFirst() // Ignore the first emitted value
             .sink { [weak self] accountId in
                 self?.saveDefaultAccount(accountId)
                 self?.loadTransactions()

--- a/MMEX/Views/Accounts/AccountAddView.swift
+++ b/MMEX/Views/Accounts/AccountAddView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AccountAddView: View {
     @Binding var newAccount: AccountWithCurrency
     @Binding var isPresentingAccountAddView: Bool
-    @Binding var currencies: [CurrencyData] // Bind to the list of available currencies
+    @Binding var currencies: [IdName] // Bind to the list of available currencies
 
     var onSave: (inout AccountWithCurrency) -> Void
     
@@ -38,7 +38,9 @@ struct AccountAddView: View {
     AccountAddView(
         newAccount: .constant(AccountWithCurrency()),
         isPresentingAccountAddView: .constant(true),
-        currencies: .constant(CurrencyData.sampleData)
+        currencies: .constant(CurrencyData.sampleData.map {
+            IdName(id: $0.id, name: $0.name)
+        } )
     ) { newAccount in
         // Handle saving in preview
         print("New account: \(newAccount.data.name)")

--- a/MMEX/Views/Accounts/AccountAddView.swift
+++ b/MMEX/Views/Accounts/AccountAddView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AccountAddView: View {
     @Binding var newAccount: AccountWithCurrency
     @Binding var isPresentingAccountAddView: Bool
-    @Binding var currencies: [IdName] // Bind to the list of available currencies
+    @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
     var onSave: (inout AccountWithCurrency) -> Void
     
@@ -39,7 +39,7 @@ struct AccountAddView: View {
         newAccount: .constant(AccountWithCurrency()),
         isPresentingAccountAddView: .constant(true),
         currencies: .constant(CurrencyData.sampleData.map {
-            IdName(id: $0.id, name: $0.name)
+            ($0.id, $0.name)
         } )
     ) { newAccount in
         // Handle saving in preview

--- a/MMEX/Views/Accounts/AccountAddView.swift
+++ b/MMEX/Views/Accounts/AccountAddView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct AccountAddView: View {
-    @Binding var newAccount: AccountWithCurrency
+    @Binding var newAccount: AccountData
     @Binding var isPresentingAccountAddView: Bool
     @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
-    var onSave: (inout AccountWithCurrency) -> Void
+    var onSave: (inout AccountData) -> Void
     
     var body: some View {
         NavigationStack {
@@ -36,13 +36,13 @@ struct AccountAddView: View {
 
 #Preview {
     AccountAddView(
-        newAccount: .constant(AccountWithCurrency()),
+        newAccount: .constant(AccountData()),
         isPresentingAccountAddView: .constant(true),
         currencies: .constant(CurrencyData.sampleData.map {
             ($0.id, $0.name)
         } )
     ) { newAccount in
         // Handle saving in preview
-        print("New account: \(newAccount.data.name)")
+        print("New account: \(newAccount.name)")
     }
 }

--- a/MMEX/Views/Accounts/AccountDetailView.swift
+++ b/MMEX/Views/Accounts/AccountDetailView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AccountDetailView: View {
     @State var account: AccountWithCurrency
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
-    @Binding var currencies: [IdName] // Bind to the list of available currencies
+    @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
     @State private var editingAccount = AccountWithCurrency()
     @State private var isPresentingEditView = false
@@ -136,7 +136,7 @@ struct AccountDetailView: View {
     AccountDetailView(
         account: AccountData.sampleDataWithCurrency[0],
         currencies: .constant(CurrencyData.sampleData.map {
-            IdName(id: $0.id, name: $0.name)
+            ($0.id, $0.name)
         } )
     )
 }
@@ -145,7 +145,7 @@ struct AccountDetailView: View {
     AccountDetailView(
         account: AccountData.sampleDataWithCurrency[1],
         currencies: .constant(CurrencyData.sampleData.map {
-            IdName(id: $0.id, name: $0.name)
+            ($0.id, $0.name)
         } )
     )
 }

--- a/MMEX/Views/Accounts/AccountDetailView.swift
+++ b/MMEX/Views/Accounts/AccountDetailView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct AccountDetailView: View {
-    @State var account: AccountWithCurrency
+    @State var account: AccountData
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
     @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
-    @State private var editingAccount = AccountWithCurrency()
+    @State private var editingAccount = AccountData()
     @State private var isPresentingEditView = false
     @Environment(\.presentationMode) var presentationMode
     
@@ -21,34 +21,34 @@ struct AccountDetailView: View {
     var body: some View {
         List {
             Section(header: Text("Account Name")) {
-                Text(account.data.name)
+                Text(account.name)
             }
             Section(header: Text("Account Type")) {
-                Text(account.data.type.name)
+                Text(account.type.name)
             }
             Section(header: Text("Status")) {
-                Text(account.data.status.id)
+                Text(account.status.id)
             }
             // TODO link to currency details
             Section(header: Text("Currency")) {
-                if let currency = account.currency {
+                if let currency = dataManager.currencyFormat[account.currencyId] {
                     Text(currency.name)
                 } else {
                     Text("Loading currency...")
                 }
             }
             Section(header: Text("Initial Date")) {
-                Text(account.data.initialDate)
+                Text(account.initialDate)
             }
             Section(header: Text("Initial Balance")) {
-                if let currency = account.currency {
-                    Text(currency.format(amount: account.data.initialBal))
+                if let currency = dataManager.currencyFormat[account.currencyId] {
+                    Text(currency.format(amount: account.initialBal))
                 } else {
-                    Text("\(account.data.initialBal)")
+                    Text("\(account.initialBal)")
                 }
             }
             Section(header: Text("Notes")) {
-                Text(account.data.notes)  // Display notes if they are not nil
+                Text(account.notes)  // Display notes if they are not nil
             }
             Button("Delete Account") {
                 deleteAccount()
@@ -81,7 +81,7 @@ struct AccountDetailView: View {
                 AccountEditView(
                     account: $editingAccount, currencies: $currencies
                 )
-                .navigationTitle(account.data.name)
+                .navigationTitle(account.name)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") {
@@ -102,7 +102,7 @@ struct AccountDetailView: View {
             isPresented: $isExporting,
             document: ExportableEntityDocument(entity: account),
             contentType: .json,
-            defaultFilename: "\(account.data.name)_Account"
+            defaultFilename: "\(account.name)_Account"
         ) { result in
             switch result {
             case .success(let url):
@@ -115,7 +115,7 @@ struct AccountDetailView: View {
 
     func saveChanges() {
         guard let repository = dataManager.accountRepository else { return }
-        if repository.update(account.data) {
+        if repository.update(account) {
             // Successfully updated
         } else {
             // Handle failure
@@ -124,7 +124,7 @@ struct AccountDetailView: View {
     
     func deleteAccount() {
         guard let repository = dataManager.accountRepository else { return }
-        if repository.delete(account.data) {
+        if repository.delete(account) {
             presentationMode.wrappedValue.dismiss()
         } else {
             // Handle deletion failure
@@ -134,7 +134,7 @@ struct AccountDetailView: View {
 
 #Preview {
     AccountDetailView(
-        account: AccountData.sampleDataWithCurrency[0],
+        account: AccountData.sampleData[0],
         currencies: .constant(CurrencyData.sampleData.map {
             ($0.id, $0.name)
         } )
@@ -143,7 +143,7 @@ struct AccountDetailView: View {
 
 #Preview {
     AccountDetailView(
-        account: AccountData.sampleDataWithCurrency[1],
+        account: AccountData.sampleData[1],
         currencies: .constant(CurrencyData.sampleData.map {
             ($0.id, $0.name)
         } )

--- a/MMEX/Views/Accounts/AccountDetailView.swift
+++ b/MMEX/Views/Accounts/AccountDetailView.swift
@@ -117,6 +117,9 @@ struct AccountDetailView: View {
         guard let repository = dataManager.accountRepository else { return }
         if repository.update(account) {
             // Successfully updated
+            if dataManager.currencyFormat[account.currencyId] == nil {
+                dataManager.loadCurrencyFormat()
+            }
         } else {
             // Handle failure
         }

--- a/MMEX/Views/Accounts/AccountDetailView.swift
+++ b/MMEX/Views/Accounts/AccountDetailView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AccountDetailView: View {
     @State var account: AccountWithCurrency
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
-    @Binding var currencies: [CurrencyData] // Bind to the list of available currencies
+    @Binding var currencies: [IdName] // Bind to the list of available currencies
 
     @State private var editingAccount = AccountWithCurrency()
     @State private var isPresentingEditView = false
@@ -35,8 +35,12 @@ struct AccountDetailView: View {
                     Text(currency.name)
                 } else {
                     Text("Loading currency...")
-                }            }
-            Section(header: Text("Balance")) {
+                }
+            }
+            Section(header: Text("Initial Date")) {
+                Text(account.data.initialDate)
+            }
+            Section(header: Text("Initial Balance")) {
                 if let currency = account.currency {
                     Text(currency.format(amount: account.data.initialBal))
                 } else {
@@ -49,6 +53,7 @@ struct AccountDetailView: View {
             Button("Delete Account") {
                 deleteAccount()
             }
+            .foregroundColor(.red)
         }
         .textSelection(.enabled)
         .onAppear() {
@@ -73,22 +78,24 @@ struct AccountDetailView: View {
         }
         .sheet(isPresented: $isPresentingEditView) {
             NavigationStack {
-                AccountEditView(account: $editingAccount, currencies: $currencies)
-                    .navigationTitle(account.data.name)
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") {
-                                isPresentingEditView = false
-                            }
-                        }
-                        ToolbarItem(placement: .confirmationAction) {
-                            Button("Done") {
-                                isPresentingEditView = false
-                                account = editingAccount
-                                saveChanges()
-                            }
+                AccountEditView(
+                    account: $editingAccount, currencies: $currencies
+                )
+                .navigationTitle(account.data.name)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") {
+                            isPresentingEditView = false
                         }
                     }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            isPresentingEditView = false
+                            account = editingAccount
+                            saveChanges()
+                        }
+                    }
+                }
             }
         }
         .fileExporter(
@@ -128,12 +135,17 @@ struct AccountDetailView: View {
 #Preview {
     AccountDetailView(
         account: AccountData.sampleDataWithCurrency[0],
-        currencies: .constant(CurrencyData.sampleData))
+        currencies: .constant(CurrencyData.sampleData.map {
+            IdName(id: $0.id, name: $0.name)
+        } )
+    )
 }
 
 #Preview {
     AccountDetailView(
         account: AccountData.sampleDataWithCurrency[1],
-        currencies: .constant(CurrencyData.sampleData)
+        currencies: .constant(CurrencyData.sampleData.map {
+            IdName(id: $0.id, name: $0.name)
+        } )
     )
 }

--- a/MMEX/Views/Accounts/AccountEditView.swift
+++ b/MMEX/Views/Accounts/AccountEditView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AccountEditView: View {
     @Binding var account: AccountWithCurrency
-    @Binding var currencies: [IdName] // Bind to the list of available currencies
+    @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
     var body: some View {
         Form {
@@ -38,8 +38,8 @@ struct AccountEditView: View {
                     if (account.data.currencyId == 0) {
                         Text("Currency").tag(0 as Int64) // not set
                     }
-                    ForEach(currencies) { currency in
-                        Text(currency.name).tag(currency.id) // Use currency.name to display and tag by id
+                    ForEach(currencies.indices, id: \.self) { i in
+                        Text(currencies[i].1).tag(currencies[i].0) // Use currency.name to display and tag by id
                     }
                 }
                 .pickerStyle(MenuPickerStyle()) // Adjust the style of the picker as needed
@@ -69,7 +69,7 @@ struct AccountEditView: View {
     AccountEditView(
         account: .constant(AccountData.sampleDataWithCurrency[0]),
         currencies: .constant(CurrencyData.sampleData.map {
-            IdName(id: $0.id, name: $0.name)
+            ($0.id, $0.name)
         } )
     )
 }
@@ -78,8 +78,7 @@ struct AccountEditView: View {
     AccountEditView(
         account: .constant(AccountData.sampleDataWithCurrency[1]),
         currencies: .constant(CurrencyData.sampleData.map {
-            IdName(id: $0.id, name: $0.name)
-
+            ($0.id, $0.name)
         } )
     )
 }

--- a/MMEX/Views/Accounts/AccountEditView.swift
+++ b/MMEX/Views/Accounts/AccountEditView.swift
@@ -45,11 +45,10 @@ struct AccountEditView: View {
                 .pickerStyle(MenuPickerStyle()) // Adjust the style of the picker as needed
             }
             Section(header: Text("Favorite Account")) {
-                Toggle(isOn: Binding(get: {
-                    account.data.favoriteAcct == "TRUE"
-                }, set: { newValue in
-                    account.data.favoriteAcct = newValue ? "TRUE" : "FALSE"
-                })) {
+                Toggle(isOn: Binding(
+                    get: { account.data.favoriteAcct == "TRUE" },
+                    set: { account.data.favoriteAcct = $0 ? "TRUE" : "FALSE" }
+                )) {
                     Text("Favorite Account")
                 }
             }

--- a/MMEX/Views/Accounts/AccountEditView.swift
+++ b/MMEX/Views/Accounts/AccountEditView.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 
 struct AccountEditView: View {
-    @Binding var account: AccountWithCurrency
+    @Binding var account: AccountData
     @Binding var currencies: [(Int64, String)] // Bind to the list of available currencies
 
     var body: some View {
         Form {
             Section(header: Text("Account Name")) {
-                TextField("Account Name", text: $account.data.name)
+                TextField("Account Name", text: $account.name)
             }
             Section(header: Text("Account Type")) {
-                Picker("Account Type", selection: $account.data.type) {
+                Picker("Account Type", selection: $account.type) {
                     ForEach(AccountType.allCases) { type in
                         Text(type.name).tag(type)
                     }
@@ -26,7 +26,7 @@ struct AccountEditView: View {
                 .pickerStyle(MenuPickerStyle()) // Adjust the style of the picker as needed
             }
             Section(header: Text("Status")) {
-                Picker("Status", selection: $account.data.status) {
+                Picker("Status", selection: $account.status) {
                     ForEach(AccountStatus.allCases) { status in
                         Text(status.name).tag(status)
                     }
@@ -34,8 +34,8 @@ struct AccountEditView: View {
                 .pickerStyle(SegmentedPickerStyle())
             }
             Section(header: Text("Currency")) {
-                Picker("Currency", selection: $account.data.currencyId) {
-                    if (account.data.currencyId == 0) {
+                Picker("Currency", selection: $account.currencyId) {
+                    if (account.currencyId == 0) {
                         Text("Currency").tag(0 as Int64) // not set
                     }
                     ForEach(currencies.indices, id: \.self) { i in
@@ -46,19 +46,19 @@ struct AccountEditView: View {
             }
             Section(header: Text("Favorite Account")) {
                 Toggle(isOn: Binding(
-                    get: { account.data.favoriteAcct == "TRUE" },
-                    set: { account.data.favoriteAcct = $0 ? "TRUE" : "FALSE" }
+                    get: { account.favoriteAcct == "TRUE" },
+                    set: { account.favoriteAcct = $0 ? "TRUE" : "FALSE" }
                 )) {
                     Text("Favorite Account")
                 }
             }
             Section(header: Text("Initial Balance")) {
-                TextField("Balance", value: $account.data.initialBal, format: .number)
+                TextField("Balance", value: $account.initialBal, format: .number)
             }
             Section(header: Text("Notes")) {
                 TextField("Notes", text: Binding(
-                    get: { account.data.notes },  // Provide a default value if nil
-                    set: { account.data.notes = $0 }  // Set nil if empty
+                    get: { account.notes },  // Provide a default value if nil
+                    set: { account.notes = $0 }  // Set nil if empty
                 ))
             }
         }
@@ -67,7 +67,7 @@ struct AccountEditView: View {
 
 #Preview {
     AccountEditView(
-        account: .constant(AccountData.sampleDataWithCurrency[0]),
+        account: .constant(AccountData.sampleData[0]),
         currencies: .constant(CurrencyData.sampleData.map {
             ($0.id, $0.name)
         } )
@@ -76,7 +76,7 @@ struct AccountEditView: View {
 
 #Preview {
     AccountEditView(
-        account: .constant(AccountData.sampleDataWithCurrency[1]),
+        account: .constant(AccountData.sampleData[1]),
         currencies: .constant(CurrencyData.sampleData.map {
             ($0.id, $0.name)
         } )

--- a/MMEX/Views/Accounts/AccountEditView.swift
+++ b/MMEX/Views/Accounts/AccountEditView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AccountEditView: View {
     @Binding var account: AccountWithCurrency
-    @Binding var currencies: [CurrencyData] // Bind to the list of available currencies
+    @Binding var currencies: [IdName] // Bind to the list of available currencies
 
     var body: some View {
         Form {
@@ -52,7 +52,7 @@ struct AccountEditView: View {
                     Text("Favorite Account")
                 }
             }
-            Section(header: Text("Balance")) {
+            Section(header: Text("Initial Balance")) {
                 TextField("Balance", value: $account.data.initialBal, format: .number)
             }
             Section(header: Text("Notes")) {
@@ -68,13 +68,18 @@ struct AccountEditView: View {
 #Preview {
     AccountEditView(
         account: .constant(AccountData.sampleDataWithCurrency[0]),
-        currencies: .constant(CurrencyData.sampleData)
+        currencies: .constant(CurrencyData.sampleData.map {
+            IdName(id: $0.id, name: $0.name)
+        } )
     )
 }
 
 #Preview {
     AccountEditView(
         account: .constant(AccountData.sampleDataWithCurrency[1]),
-        currencies: .constant(CurrencyData.sampleData)
+        currencies: .constant(CurrencyData.sampleData.map {
+            IdName(id: $0.id, name: $0.name)
+
+        } )
     )
 }

--- a/MMEX/Views/Accounts/AccountListView.swift
+++ b/MMEX/Views/Accounts/AccountListView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct AccountListView: View {
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
-    @State private var currencies: [IdName] = []
+    @State private var currencies: [(Int64, String)] = []
     @State private var accounts_by_type: [String:[AccountWithCurrency]] = [:]
     @State private var newAccount = emptyAccount
     @State private var isPresentingAccountAddView = false

--- a/MMEX/Views/Accounts/AccountListView.swift
+++ b/MMEX/Views/Accounts/AccountListView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct AccountListView: View {
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
-    @State private var currencies: [(Int64, String)] = []
+    @State private var currencies: [(Int64, String)] = [] // only the name is needed
     @State private var accounts_by_type: [String:[AccountWithCurrency]] = [:]
     @State private var newAccount = emptyAccount
     @State private var isPresentingAccountAddView = false

--- a/MMEX/Views/Accounts/AccountListView.swift
+++ b/MMEX/Views/Accounts/AccountListView.swift
@@ -48,6 +48,7 @@ struct AccountListView: View {
                         // Show account list based on expandedSections state
                         if expandedSections[accountType] == true {
                             ForEach(accounts_by_type[accountType]!) { account in
+                                // TODO: update View after change in account
                                 NavigationLink(destination: AccountDetailView(
                                     account: account, currencies: $currencies
                                 ) ) {
@@ -131,6 +132,9 @@ struct AccountListView: View {
         guard let repository = dataManager.accountRepository else { return }
         if repository.insert(&account) {
             // self.accounts.append(account)
+            if dataManager.currencyFormat[account.currencyId] == nil {
+                dataManager.loadCurrencyFormat()
+            }
             self.loadAccounts()
         }
     }

--- a/MMEX/Views/Accounts/AccountListView.swift
+++ b/MMEX/Views/Accounts/AccountListView.swift
@@ -9,15 +9,12 @@ import SwiftUI
 struct AccountListView: View {
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
     @State private var currencies: [(Int64, String)] = [] // only the name is needed
-    @State private var accounts_by_type: [String:[AccountWithCurrency]] = [:]
+    @State private var accounts_by_type: [String:[AccountData]] = [:]
     @State private var newAccount = emptyAccount
     @State private var isPresentingAccountAddView = false
     @State private var expandedSections: [String: Bool] = [:] // Tracks the expanded/collapsed state
-    static let emptyAccount = AccountWithCurrency(
-        data : AccountData(
-            status: AccountStatus.open
-        ),
-        currency: nil
+    static let emptyAccount = AccountData(
+        status: AccountStatus.open
     )
 
     var body: some View {
@@ -55,12 +52,12 @@ struct AccountListView: View {
                                     account: account, currencies: $currencies
                                 ) ) {
                                     HStack {
-                                        Text(account.data.name)
+                                        Text(account.name)
                                             .font(.subheadline)
 
                                         Spacer()
 
-                                        if let currency = account.currency {
+                                        if let currency = dataManager.currencyFormat[account.currencyId] {
                                             Text(currency.name)
                                                 .font(.subheadline)
                                         }
@@ -109,10 +106,10 @@ struct AccountListView: View {
         print("Loading payees in AccountListView...")
         let repository = dataManager.accountRepository
         DispatchQueue.global(qos: .background).async {
-            let loadedAccounts = repository?.loadWithCurrency() ?? []
+            let loadedAccounts = repository?.load() ?? []
             DispatchQueue.main.async {
                 self.accounts_by_type = Dictionary(grouping: loadedAccounts) { account in
-                    account.data.type.name
+                    account.type.name
                 }
                 self.initializeExpandedSections() // Initialize expanded states
             }
@@ -130,9 +127,9 @@ struct AccountListView: View {
         }
     }
 
-    func addAccount(account: inout AccountWithCurrency) {
-        let repository = dataManager.accountRepository
-        if repository?.insert(&(account.data)) == true {
+    func addAccount(account: inout AccountData) {
+        guard let repository = dataManager.accountRepository else { return }
+        if repository.insert(&account) {
             // self.accounts.append(account)
             self.loadAccounts()
         }

--- a/MMEX/Views/Accounts/AccountListView.swift
+++ b/MMEX/Views/Accounts/AccountListView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct AccountListView: View {
     @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
-    @State private var currencies: [CurrencyData] = []
+    @State private var currencies: [IdName] = []
     @State private var accounts_by_type: [String:[AccountWithCurrency]] = [:]
     @State private var newAccount = emptyAccount
     @State private var isPresentingAccountAddView = false
@@ -51,7 +51,9 @@ struct AccountListView: View {
                         // Show account list based on expandedSections state
                         if expandedSections[accountType] == true {
                             ForEach(accounts_by_type[accountType]!) { account in
-                                NavigationLink(destination: AccountDetailView(account: account, currencies: $currencies)) {
+                                NavigationLink(destination: AccountDetailView(
+                                    account: account, currencies: $currencies
+                                ) ) {
                                     HStack {
                                         Text(account.data.name)
                                             .font(.subheadline)
@@ -85,7 +87,11 @@ struct AccountListView: View {
             loadCurrencies()
         }
         .sheet(isPresented: $isPresentingAccountAddView) {
-            AccountAddView(newAccount: $newAccount, isPresentingAccountAddView: $isPresentingAccountAddView, currencies: $currencies) { newAccount in
+            AccountAddView(
+                newAccount: $newAccount,
+                isPresentingAccountAddView: $isPresentingAccountAddView,
+                currencies: $currencies
+            ) { newAccount in
                 addAccount(account: &newAccount)
                 newAccount = Self.emptyAccount
             }
@@ -101,7 +107,6 @@ struct AccountListView: View {
     
     func loadAccounts() {
         print("Loading payees in AccountListView...")
-
         let repository = dataManager.accountRepository
         DispatchQueue.global(qos: .background).async {
             let loadedAccounts = repository?.loadWithCurrency() ?? []
@@ -116,9 +121,8 @@ struct AccountListView: View {
     
     func loadCurrencies() {
         let repo = dataManager.currencyRepository
-
         DispatchQueue.global(qos: .background).async {
-            let loadedCurrencies = repo?.load() ?? []
+            let loadedCurrencies = repo?.loadName() ?? []
             DispatchQueue.main.async {
                 self.currencies = loadedCurrencies
                 // other post op

--- a/MMEX/Views/Currencies/CurrencyDetailView.swift
+++ b/MMEX/Views/Currencies/CurrencyDetailView.swift
@@ -32,7 +32,7 @@ struct CurrencyDetailView: View {
                 Text("\(currency.baseConvRate)")
             }
             Section(header: Text("Currency Type")) {
-                Text(currency.type)
+                Text(currency.type.rawValue)
             }
             Button("Delete Currency") {
                 deleteCurrency()

--- a/MMEX/Views/Currencies/CurrencyEditView.swift
+++ b/MMEX/Views/Currencies/CurrencyEditView.swift
@@ -34,7 +34,13 @@ struct CurrencyEditView: View {
                 TextField("Conversion Rate", value: $currency.baseConvRate, format: .number)
             }
             Section(header: Text("Currency Type")) {
-                TextField("Currency Type", text: $currency.type)
+                Picker("Currency Type", selection: $currency.type) {
+                    ForEach(CurrencyType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(MenuPickerStyle()) // Adjust the style of the picker as needed
             }
         }
     }

--- a/MMEX/Views/Currencies/CurrencyListView.swift
+++ b/MMEX/Views/Currencies/CurrencyListView.swift
@@ -17,8 +17,7 @@ struct CurrencyListView: View {
         decimalPoint   : ".",
         groupSeparator : ",",
         scale          : 100,
-        baseConvRate   : 1.0,
-        type           : "Fiat"
+        baseConvRate   : 1.0
     )
 
     var body: some View {

--- a/MMEX/Views/ManagementView.swift
+++ b/MMEX/Views/ManagementView.swift
@@ -16,23 +16,23 @@ struct ManagementView: View {
     var body: some View {
         List {
             Section(header: Text("Manage Data")) {
+                NavigationLink(destination: CurrencyListView()) {
+                    Text("Manage Currencies")
+                }
                 NavigationLink(destination: AccountListView()) {
                     Text("Manage Accounts")
                 }
                 NavigationLink(destination: AssetListView()) {
                     Text("Manage Assets")
                 }
-                NavigationLink(destination: PayeeListView()) {
-                    Text("Manage Payees")
-                }
                 NavigationLink(destination: CategoryListView()) {
                     Text("Manage Categories")
                 }
+                NavigationLink(destination: PayeeListView()) {
+                    Text("Manage Payees")
+                }
                 NavigationLink(destination: TransactionListView()) {
                     Text("Manage Transactions")
-                }
-                NavigationLink(destination: CurrencyListView()) {
-                    Text("Manage Currencies")
                 }
             }
             

--- a/MMEX/Views/Settings/SettingsView.swift
+++ b/MMEX/Views/Settings/SettingsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject var dataManager: DataManager // Access DataManager from environment
     @ObservedObject var viewModel: InfotableViewModel
     
     @AppStorage("defaultPayeeSetting") private var defaultPayeeSetting: DefaultPayeeSetting = .none
@@ -74,9 +75,9 @@ struct SettingsView: View {
                 Picker("Base Currency", selection: $viewModel.baseCurrencyId) {
                     ForEach(viewModel.currencies) { currency in
                         HStack {
-                            Text(currency.symbol)
-                            Spacer()
                             Text(currency.name)
+                            Spacer()
+                            Text(currency.symbol)
                         }
                         .tag(currency.id) // Use currency.name to display and tag by id
                     }
@@ -85,10 +86,11 @@ struct SettingsView: View {
  
                 Picker("Default Account", selection: $viewModel.defaultAccountId) {
                     ForEach(viewModel.accounts) { account in
+                        let currency = dataManager.currencyFormat[account.currencyId]
                         HStack {
-                            Text(account.data.name)
+                            Text(account.name)
                             Spacer()
-                            Text(account.currency?.symbol ?? "")
+                            Text(currency?.name ?? "")
                         }
                         .tag(account.id)
                     }

--- a/MMEX/Views/Transactions/TransactionAddView.swift
+++ b/MMEX/Views/Transactions/TransactionAddView.swift
@@ -13,7 +13,7 @@ struct TransactionAddView: View {
     
     @Binding var payees: [PayeeData]
     @Binding var categories: [CategoryData]
-    @Binding var accounts: [AccountWithCurrency]
+    @Binding var accounts: [AccountData]
     
     var onSave: (inout TransactionData) -> Void
     
@@ -47,7 +47,7 @@ struct TransactionAddView: View {
         isPresentingTransactionAddView: .constant(true),
         payees: .constant(PayeeData.sampleData),
         categories: .constant(CategoryData.sampleData),
-        accounts: .constant(AccountData.sampleDataWithCurrency)
+        accounts: .constant(AccountData.sampleData)
     ) { newTxn in
         // Handle saving in preview
         print("New payee: \(newTxn.id)")

--- a/MMEX/Views/Transactions/TransactionAddView2.swift
+++ b/MMEX/Views/Transactions/TransactionAddView2.swift
@@ -17,7 +17,7 @@ struct TransactionAddView2: View {
     
     @State private var payees: [PayeeData] = []
     @State private var categories: [CategoryData] = []
-    @State private var accounts: [AccountWithCurrency] = []
+    @State private var accounts: [AccountData] = []
     
     var body: some View {
         NavigationStack {
@@ -93,7 +93,7 @@ struct TransactionAddView2: View {
     
     func loadAccounts() {
         DispatchQueue.global(qos: .background).async {
-            let loadedAccounts = dataManager.accountRepository?.loadWithCurrency() ?? []
+            let loadedAccounts = dataManager.accountRepository?.load() ?? []
             DispatchQueue.main.async {
                 self.accounts = loadedAccounts
             }

--- a/MMEX/Views/Transactions/TransactionDetailView.swift
+++ b/MMEX/Views/Transactions/TransactionDetailView.swift
@@ -33,8 +33,10 @@ struct TransactionDetailView: View {
             }
 
             Section(header: Text("Transaction Amount")) {
-                if let currency = account?.currency {
-                    Text(currency.format(amount: txn.transAmount))
+                if let currency = account?.currency,
+                   let currencyFormat = dataManager.currencyFormat[currency.id]
+                {
+                    Text(currencyFormat.format(amount: txn.transAmount))
                 } else {
                     Text("\(txn.transAmount)")
                 }

--- a/MMEX/Views/Transactions/TransactionDetailView.swift
+++ b/MMEX/Views/Transactions/TransactionDetailView.swift
@@ -17,9 +17,9 @@ struct TransactionDetailView: View {
     
     @Binding var payees: [PayeeData]
     @Binding var categories: [CategoryData]
-    @Binding var accounts: [AccountWithCurrency]
+    @Binding var accounts: [AccountData]
     
-    @State private var account: AccountWithCurrency?
+    @State private var account: AccountData?
     @State private var isExporting = false
 
     var body: some View {
@@ -33,8 +33,8 @@ struct TransactionDetailView: View {
             }
 
             Section(header: Text("Transaction Amount")) {
-                if let currency = account?.currency,
-                   let currencyFormat = dataManager.currencyFormat[currency.id]
+                if let currencyId = account?.currencyId,
+                   let currencyFormat = dataManager.currencyFormat[currencyId]
                 {
                     Text(currencyFormat.format(amount: txn.transAmount))
                 } else {
@@ -48,7 +48,7 @@ struct TransactionDetailView: View {
 
             Section(header: Text("Account Name")) {
                 if let account = account {
-                    Text("\(account.data.name)")
+                    Text("\(account.name)")
                 } else {
                     Text("n/a")
                 }
@@ -125,8 +125,9 @@ struct TransactionDetailView: View {
     }
     
     func loadAccount() {
-        account = accounts.first { $0.data.id == txn.accountId}
+        account = accounts.first { $0.id == txn.accountId}
     }
+
     func saveChanges() {
         let repository = dataManager.transactionRepository // pass URL here
         if repository?.update(txn) == true {
@@ -153,6 +154,6 @@ struct TransactionDetailView: View {
         txn: TransactionData.sampleData[0],
         payees: .constant(PayeeData.sampleData),
         categories: .constant(CategoryData.sampleData),
-        accounts: .constant(AccountData.sampleDataWithCurrency)
+        accounts: .constant(AccountData.sampleData)
     )
 }

--- a/MMEX/Views/Transactions/TransactionEditView.swift
+++ b/MMEX/Views/Transactions/TransactionEditView.swift
@@ -14,7 +14,7 @@ struct TransactionEditView: View {
 
     @Binding var payees: [PayeeData]
     @Binding var categories: [CategoryData]
-    @Binding var accounts: [AccountWithCurrency]
+    @Binding var accounts: [AccountData]
     
     // app level setting
     @AppStorage("defaultPayeeSetting") private var defaultPayeeSetting: DefaultPayeeSetting = .none
@@ -41,7 +41,7 @@ struct TransactionEditView: View {
                         Text("Account").tag(0 as Int64) // not set
                     }
                     ForEach(accounts) { account in
-                        Text(account.data.name).tag(account.data.id)
+                        Text(account.name).tag(account.id)
                     }
                 }
             }
@@ -151,7 +151,7 @@ struct TransactionEditView: View {
             }
 
             if self.accounts.count == 1 {
-                txn.accountId = self.accounts.first!.data.id
+                txn.accountId = self.accounts.first!.id
             }
 
             if self.categories.count == 1 {
@@ -174,6 +174,6 @@ struct TransactionEditView: View {
         txn: .constant(TransactionData.sampleData[0]),
         payees: .constant(PayeeData.sampleData),
         categories: .constant(CategoryData.sampleData),
-        accounts: .constant(AccountData.sampleDataWithCurrency)
+        accounts: .constant(AccountData.sampleData)
     )
 }

--- a/MMEX/Views/Transactions/TransactionListView2.swift
+++ b/MMEX/Views/Transactions/TransactionListView2.swift
@@ -15,8 +15,8 @@ struct TransactionListView2: View {
     @State private var payeeDict: [Int64: PayeeData] = [:] // for lookup
     @State private var categories: [CategoryData] = []
     @State private var categoryDict: [Int64: CategoryData] = [:] // for lookup
-    @State private var accounts: [AccountWithCurrency] = []
-    @State private var accountDict: [Int64: AccountWithCurrency] = [: ] // for lookup
+    @State private var accounts: [AccountData] = []
+    @State private var accountDict: [Int64: AccountData] = [: ] // for lookup
     
     var body: some View {
         NavigationStack {
@@ -50,11 +50,11 @@ struct TransactionListView2: View {
                     Picker("Select Account", selection: $viewModel.defaultAccountId) {
                         ForEach(self.accounts) { account in
                             HStack{
-                                Image(systemName: account.data.type.symbolName)
+                                Image(systemName: account.type.symbolName)
                                     .frame(width: 5, alignment: .leading) // Adjust width as needed
                                     .font(.system(size: 16, weight: .bold)) // Customize size and weight
                                     .foregroundColor(.blue) // Customize icon style
-                                Text(account.data.name)
+                                Text(account.name)
                             }.tag(account.id)
                         }
                     }
@@ -101,7 +101,7 @@ struct TransactionListView2: View {
 
                 Spacer() // To push the amount to the right side
 
-                if let currencyId = self.accountDict[txn.accountId]?.data.currencyId,
+                if let currencyId = self.accountDict[txn.accountId]?.currencyId,
                    let currencyFormat = dataManager.currencyFormat[currencyId]
                 {
                     // Right column (Transaction Amount)
@@ -152,10 +152,8 @@ struct TransactionListView2: View {
     
     func loadCategories() {
         let repository = dataManager.categoryRepository
-
         DispatchQueue.global(qos: .background).async {
             let loadedCategories = repository?.load() ?? []
-            
             DispatchQueue.main.async {
                 self.categories = loadedCategories
                 self.categoryDict = Dictionary(uniqueKeysWithValues: categories.map { ($0.id, $0) })
@@ -165,10 +163,8 @@ struct TransactionListView2: View {
     
     func loadAccounts() {
         let repository = dataManager.accountRepository
-
         DispatchQueue.global(qos: .background).async {
-            let loadedAccounts = repository?.loadWithCurrency() ?? []
-            
+            let loadedAccounts = repository?.load() ?? []
             DispatchQueue.main.async {
                 self.accounts = loadedAccounts
                 self.accountDict = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0) })


### PR DESCRIPTION
## Problem

The currencies are loaded too many times. Every click on the tabs at the bottom re-loads all currencies 2-3 times. 

## Changes

-`CurrencyFormat` contains only the data needed for formatting.

- `CurrencyRepository.dictionaryRefFormat()` loads only the currency formats referred by any Account or Asset (all other tables refer to currencies indirectly through these two).

- `DataManager.currencyFormat` stores the currency formats when the database is open.

## Note

The information in `DataManager.currencyFormat` is sufficient for the most frequent access to CurrencyData. It is not sufficient for the Currency Views (which need to load more information on demand).

The Views which refer to Currency directly (Account, Asset) need also a list of all currencies. This information is (will be) loaded on demand.