### PR TITLE
Add InsightsAccountView

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		9208242C2CA615B400388AB2 /* FieldRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9208242B2CA615B400388AB2 /* FieldRepository.swift */; };
 		9208242E2CA617FB00388AB2 /* FieldContentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9208242D2CA617FB00388AB2 /* FieldContentRepository.swift */; };
 		920824322CA6E32800388AB2 /* RepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920824312CA6E32800388AB2 /* RepositoryProtocol.swift */; };
+		924352E02CA9CC5A0052E4BC /* InsightsAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924352DF2CA9CC5A0052E4BC /* InsightsAccountView.swift */; };
 		929EF65F2C9FF2DE0051A3E6 /* AssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929EF65E2C9FF2DE0051A3E6 /* AssetData.swift */; };
 		929EF6612C9FF2FD0051A3E6 /* StockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929EF6602C9FF2FD0051A3E6 /* StockData.swift */; };
 		929EF6632C9FF3ED0051A3E6 /* AssetRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929EF6622C9FF3ED0051A3E6 /* AssetRepository.swift */; };
@@ -53,8 +54,8 @@
 		A3363EE72C93249D004696C7 /* CategoryAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EE62C93249D004696C7 /* CategoryAddView.swift */; };
 		A3363EE92C9326A1004696C7 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EE82C9326A1004696C7 /* CategoryListView.swift */; };
 		A3363EEB2C93BF62004696C7 /* CurrencyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EEA2C93BF62004696C7 /* CurrencyRepository.swift */; };
-		A33742882CA8E55400698466 /* IncomeAndExpense.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742872CA8E55400698466 /* IncomeAndExpense.swift */; };
-		A337428A2CA8E72C00698466 /* Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742892CA8E72C00698466 /* Summary.swift */; };
+		A33742882CA8E55400698466 /* IncomeExpenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742872CA8E55400698466 /* IncomeExpenseView.swift */; };
+		A337428A2CA8E72C00698466 /* InsightsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742892CA8E72C00698466 /* InsightsSummary.swift */; };
 		A3462F642C9426F500F79145 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3462F632C9426F500F79145 /* InsightsViewModel.swift */; };
 		A3462F662C94854800F79145 /* ExportableEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3462F652C94854800F79145 /* ExportableEntity.swift */; };
 		A3462F6A2C948CDB00F79145 /* ExportableEntityDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3462F692C948CDB00F79145 /* ExportableEntityDocument.swift */; };
@@ -142,6 +143,7 @@
 		9208242B2CA615B400388AB2 /* FieldRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FieldRepository.swift; sourceTree = "<group>"; };
 		9208242D2CA617FB00388AB2 /* FieldContentRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FieldContentRepository.swift; sourceTree = "<group>"; };
 		920824312CA6E32800388AB2 /* RepositoryProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryProtocol.swift; sourceTree = "<group>"; };
+		924352DF2CA9CC5A0052E4BC /* InsightsAccountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsightsAccountView.swift; sourceTree = "<group>"; };
 		929EF65E2C9FF2DE0051A3E6 /* AssetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetData.swift; sourceTree = "<group>"; };
 		929EF6602C9FF2FD0051A3E6 /* StockData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StockData.swift; sourceTree = "<group>"; };
 		929EF6622C9FF3ED0051A3E6 /* AssetRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetRepository.swift; sourceTree = "<group>"; };
@@ -158,8 +160,8 @@
 		A3363EE62C93249D004696C7 /* CategoryAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryAddView.swift; sourceTree = "<group>"; };
 		A3363EE82C9326A1004696C7 /* CategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListView.swift; sourceTree = "<group>"; };
 		A3363EEA2C93BF62004696C7 /* CurrencyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRepository.swift; sourceTree = "<group>"; };
-		A33742872CA8E55400698466 /* IncomeAndExpense.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomeAndExpense.swift; sourceTree = "<group>"; };
-		A33742892CA8E72C00698466 /* Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Summary.swift; sourceTree = "<group>"; };
+		A33742872CA8E55400698466 /* IncomeExpenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomeExpenseView.swift; sourceTree = "<group>"; };
+		A33742892CA8E72C00698466 /* InsightsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsSummary.swift; sourceTree = "<group>"; };
 		A3462F632C9426F500F79145 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
 		A3462F652C94854800F79145 /* ExportableEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportableEntity.swift; sourceTree = "<group>"; };
 		A3462F692C948CDB00F79145 /* ExportableEntityDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportableEntityDocument.swift; sourceTree = "<group>"; };
@@ -381,8 +383,9 @@
 			isa = PBXGroup;
 			children = (
 				A3C142AD2C9134DD00D3CEC0 /* InsightsView.swift */,
-				A33742872CA8E55400698466 /* IncomeAndExpense.swift */,
-				A33742892CA8E72C00698466 /* Summary.swift */,
+				924352DF2CA9CC5A0052E4BC /* InsightsAccountView.swift */,
+				A33742892CA8E72C00698466 /* InsightsSummary.swift */,
+				A33742872CA8E55400698466 /* IncomeExpenseView.swift */,
 			);
 			path = Insights;
 			sourceTree = "<group>";
@@ -582,7 +585,7 @@
 				929EF6652C9FF3FB0051A3E6 /* StockRepository.swift in Sources */,
 				A3C142502C8B366400D3CEC0 /* PayeeListView.swift in Sources */,
 				A379C1A72CA3B79E00CC8E2C /* AssetAddView.swift in Sources */,
-				A337428A2CA8E72C00698466 /* Summary.swift in Sources */,
+				A337428A2CA8E72C00698466 /* InsightsSummary.swift in Sources */,
 				A3C142672C8F2AF500D3CEC0 /* TransactionData.swift in Sources */,
 				920824042CA4ADC100388AB2 /* ScheduledSplitData.swift in Sources */,
 				A3462F642C9426F500F79145 /* InsightsViewModel.swift in Sources */,
@@ -590,6 +593,7 @@
 				A3C142962C8FE15E00D3CEC0 /* TransactionRepository.swift in Sources */,
 				A39B1B342C99A0A8003E5562 /* CurrencyDetailView.swift in Sources */,
 				A3C1422D2C89751500D3CEC0 /* ContentView.swift in Sources */,
+				924352E02CA9CC5A0052E4BC /* InsightsAccountView.swift in Sources */,
 				929EF65F2C9FF2DE0051A3E6 /* AssetData.swift in Sources */,
 				920823FE2CA4A3F700388AB2 /* TagData.swift in Sources */,
 				A379C1A92CA3B9EB00CC8E2C /* AssetListView.swift in Sources */,
@@ -629,7 +633,7 @@
 				A3462F6A2C948CDB00F79145 /* ExportableEntityDocument.swift in Sources */,
 				920824122CA4C6A400388AB2 /* BudgetTableRepository.swift in Sources */,
 				A3C142982C8FE62200D3CEC0 /* TransactionListView.swift in Sources */,
-				A33742882CA8E55400698466 /* IncomeAndExpense.swift in Sources */,
+				A33742882CA8E55400698466 /* IncomeExpenseView.swift in Sources */,
 				A3C142542C8B381400D3CEC0 /* PayeeEditView.swift in Sources */,
 				920823F82CA498B500388AB2 /* CurrencyHistoryRepository.swift in Sources */,
 				A37E7D8A2C9AC30700B4ECFC /* HelpFAQView.swift in Sources */,

--- a/MMEX/DatabaseManager.swift
+++ b/MMEX/DatabaseManager.swift
@@ -126,7 +126,7 @@ extension DataManager {
 
 extension DataManager {
     func loadCurrencyFormat() {
-        currencyFormat = CurrencyRepository(db)?.dictionaryRefFormat() ?? [:]
+        currencyFormat = CurrencyRepository(db)?.dictRefFormat() ?? [:]
     }
 
     func updateCurrencyFormat(id: Int64, value: CurrencyFormat) {

--- a/MMEX/Models/AccountData.swift
+++ b/MMEX/Models/AccountData.swift
@@ -80,6 +80,28 @@ extension AccountData: DataProtocol {
     }
 }
 
+struct AccountFlow {
+    let inflow  : Double
+    let outflow : Double
+}
+
+extension AccountFlow {
+    var diff: Double { inflow - outflow }
+}
+
+typealias AccountFlowByStatus = [TransactionStatus: AccountFlow]
+
+extension AccountFlowByStatus {
+    var diffVoid       : Double { self[.void]?        .diff ?? 0.0 }
+    var diffReconciled : Double { self[.reconciled]?  .diff ?? 0.0 }
+    var diffTotal      : Double {
+        (self[.none]?       .diff ?? 0.0) +
+        (self[.reconciled]? .diff ?? 0.0) +
+        (self[.followUp]?   .diff ?? 0.0) +
+        (self[.duplicate]?  .diff ?? 0.0)
+    }
+}
+
 extension AccountData {
     static let sampleData : [AccountData] = [
         AccountData(

--- a/MMEX/Models/TransactionData.swift
+++ b/MMEX/Models/TransactionData.swift
@@ -104,6 +104,7 @@ extension TransactionData {
         }
         return transDate // If parsing fails, return original string
     }
+
     var income: Double {
         // TODO: in base currency
         if transCode == .deposit {
@@ -111,6 +112,7 @@ extension TransactionData {
         }
         return 0.0
     }
+
     var expenses: Double {
         // TODO: in base currency
         if transCode == .withdrawal {
@@ -118,6 +120,7 @@ extension TransactionData {
         }
         return 0.0
     }
+
     var actual: Double {
         return switch transCode {
         case .withdrawal: 0 - transAmount;
@@ -125,6 +128,7 @@ extension TransactionData {
         default: 0.0
         }
     }
+
     var transfer: Double {
         // TODO: in base currency
         if transCode == .transfer {

--- a/MMEX/Repositories/CurrencyRepository.swift
+++ b/MMEX/Repositories/CurrencyRepository.swift
@@ -162,8 +162,8 @@ extension CurrencyRepository {
 
     // TODO: re-write in a more readable way (get the ids first, then pluck each currency)
     // load all referred currency formats, indexed by currencyId
-    func dictionaryRefFormat() -> [Int64: CurrencyFormat] {
-        print("DEBUG: CurrencyRepository.dictionaryRefFormat()")
+    func dictRefFormat() -> [Int64: CurrencyFormat] {
+        print("DEBUG: CurrencyRepository.dictRefFormat()")
         typealias C = CurrencyRepository
         typealias A = AccountRepository
         typealias E = AssetRepository
@@ -182,7 +182,7 @@ extension CurrencyRepository {
         " union " +
         "select 1 from \(E.repositoryName) where \(E.table[E.col_currencyId]) == \(C.table[C.col_id])" +
         ")"
-        return Repository(db).dictionary(
+        return Repository(db).dict(
             query: query
         ) { row in CurrencyFormat(
             name           : row[1] as? String ?? "",

--- a/MMEX/Repositories/Repository.swift
+++ b/MMEX/Repositories/Repository.swift
@@ -53,11 +53,11 @@ extension Repository {
         }
     }
 
-    func dictionary<Result>(
+    func dict<Result>(
         query: String,
         with result: (SQLite.Statement.Element) -> Result
     ) -> [Int64: Result] {
-        print("DEBUG: Repository.dictionary: \(query)")
+        print("DEBUG: Repository.dict: \(query)")
         do {
             var dict: [Int64: Result] = [:]
             for row in try db.prepare(query) {

--- a/MMEX/Repositories/RepositoryProtocol.swift
+++ b/MMEX/Repositories/RepositoryProtocol.swift
@@ -70,7 +70,7 @@ extension RepositoryProtocol {
         }
     }
 
-    func dictionary<Result>(
+    func dict<Result>(
         from table: SQLite.Table,
         with result: (SQLite.Row) -> Result = Self.fetchData
     ) -> [Int64: Result] {

--- a/MMEX/ViewModels/InsightsViewModel.swift
+++ b/MMEX/ViewModels/InsightsViewModel.swift
@@ -7,29 +7,32 @@
 
 import Foundation
 import SwiftUI
+import SQLite
 import Combine
 
 class InsightsViewModel: ObservableObject {
     private var dataManager: DataManager
-
-
+    
+    
     @Published var stats: [TransactionData] = [] // all transactions
     // Published properties for the view to observe
     @Published var recentStats: [TransactionData] = []
     @Published var startDate: Date
     @Published var endDate: Date
-
+    @Published var accountInfo = InsightsAccountInfo()
+    
     private var cancellables = Set<AnyCancellable>()
-
+    
     init(dataManager: DataManager) {
         self.dataManager = dataManager
         self.startDate = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
         self.endDate = Date()
-
+        
         // Load transactions on initialization
+        loadAccountInfo()
         loadRecentTransactions()
         loadTransactions()
-
+        
         // Automatically reload transactions when date range changes
         $startDate
             .combineLatest($endDate)
@@ -38,31 +41,68 @@ class InsightsViewModel: ObservableObject {
             }
             .store(in: &cancellables)
     }
-
+    
     func loadRecentTransactions() {
         let repository = dataManager.transactionRepository
-
         // Fetch transactions asynchronously
         DispatchQueue.global(qos: .background).async {
             let transactions = repository?.loadRecent(startDate: self.startDate, endDate: self.endDate) ?? []
-
             // Update the published stats on the main thread
             DispatchQueue.main.async {
                 self.recentStats = transactions
             }
         }
     }
-
+    
     func loadTransactions() {
-        if let repository = dataManager.transactionRepository {
-            // Fetch transactions asynchronously
-            DispatchQueue.global(qos: .background).async {
-                let transactions = repository.load()
+        let repository = dataManager.transactionRepository
+        // Fetch transactions asynchronously
+        DispatchQueue.global(qos: .background).async {
+            let transactions = repository?.load() ?? []
+            // Update the published stats on the main thread
+            DispatchQueue.main.async {
+                self.stats = transactions
+            }
+        }
+    }
+    
+    func loadAccountInfo() {
+        self.accountInfo.today = String(self.endDate.ISO8601Format().dropLast())
+        let repository = dataManager.accountRepository
+        typealias A = AccountRepository
+        let table = A.table
+            .filter(A.table[A.col_status] == AccountStatus.open.rawValue)
 
-                // Update the published stats on the main thread
-                DispatchQueue.main.async {
-                    self.stats = transactions
-                }
+        // fetch open accounts
+        DispatchQueue.global(qos: .background).async {
+            let dataByType = repository?.selectByType(
+                from: table.order(AccountRepository.col_name)
+            ) ?? [:]
+            // Update the published stats on the main thread
+            DispatchQueue.main.async {
+                self.accountInfo.dataByType = dataByType
+            }
+        }
+
+        // fetch flow of open accounts until today
+        DispatchQueue.global(qos: .background).async {
+            let flowByStatus = repository?.dictFlowByStatus(
+                from: table,
+                maxDate: self.accountInfo.today
+            ) ?? [:]
+            DispatchQueue.main.async {
+                self.accountInfo.flowUntilToday = flowByStatus
+            }
+        }
+
+        // fetch flow of open accounts after today
+        DispatchQueue.global(qos: .background).async {
+            let flowByStatus = repository?.dictFlowByStatus(
+                from: table,
+                minDate: self.accountInfo.today + "z"
+            ) ?? [:]
+            DispatchQueue.main.async {
+                self.accountInfo.flowUntilToday = flowByStatus
             }
         }
     }

--- a/MMEX/Views/Insights/IncomeExpenseView.swift
+++ b/MMEX/Views/Insights/IncomeExpenseView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 import Charts
 
-struct IncomeAndExpense: View {
+struct IncomeExpenseView: View {
     @Binding var stats: [TransactionData]
+
     var body: some View {
         Chart() {
             ForEach(stats) { stat in
@@ -49,5 +50,5 @@ struct IncomeAndExpense: View {
 }
 
 #Preview {
-    IncomeAndExpense(stats: .constant(TransactionData.sampleData))
+    IncomeExpenseView(stats: .constant(TransactionData.sampleData))
 }

--- a/MMEX/Views/Insights/InsightsAccountView.swift
+++ b/MMEX/Views/Insights/InsightsAccountView.swift
@@ -45,6 +45,7 @@ struct InsightsAccountView: View {
 
             ForEach(Self.typeOrder) { accountType in
                 if let accounts = accountInfo.dataByType[accountType] {
+                    Spacer(minLength: 8)
                     Section(
                         header: HStack {
                             Button(action: {
@@ -71,34 +72,37 @@ struct InsightsAccountView: View {
                     ) {
                         // Show account list based on expandedSections state
                         if expandedSections[accountType] == true {
-                            ForEach(accounts) { account in
-                                HStack {
-                                    Text(account.name)
-                                        .font(.subheadline)
-                                    
-                                    Spacer(minLength: 10)
-                                    
-                                    let flowByStatus = accountInfo.flowUntilToday[account.id]
-                                    let value: Double? = switch Self.statusChoices[statusChoice].1 {
-                                    case "Reconciled Balance" : (flowByStatus?.diffReconciled    ?? 0.0) + account.initialBal
-                                    case "Total Balance"      : (flowByStatus?.diffTotal         ?? 0.0) + account.initialBal
-                                    case "None"       : flowByStatus?[.none]?.diff
-                                    case "Duplicate"  : flowByStatus?[.duplicate]?.diff
-                                    case "Follow up"  : flowByStatus?[.followUp]?.diff
-                                    case "Void"       : flowByStatus?[.void]?.diff
-                                    default           : nil
-                                    }
-                                    if let value {
-                                        if let currency = dataManager.currencyFormat[account.currencyId] {
-                                            Text(currency.format(amount: value))
-                                                .font(.subheadline)
-                                        } else {
-                                            Text(String(format: "%.2f", value))
-                                                .font(.subheadline)
+                            VStack(spacing: 8) {
+                                Spacer(minLength: 2)
+                                ForEach(accounts) { account in
+                                    HStack {
+                                        Text(account.name)
+                                            .font(.subheadline)
+                                        
+                                        Spacer(minLength: 10)
+                                        
+                                        let flowByStatus = accountInfo.flowUntilToday[account.id]
+                                        let value: Double? = switch Self.statusChoices[statusChoice].1 {
+                                        case "Reconciled Balance" : (flowByStatus?.diffReconciled    ?? 0.0) + account.initialBal
+                                        case "Total Balance"      : (flowByStatus?.diffTotal         ?? 0.0) + account.initialBal
+                                        case "None"       : flowByStatus?[.none]?.diff
+                                        case "Duplicate"  : flowByStatus?[.duplicate]?.diff
+                                        case "Follow up"  : flowByStatus?[.followUp]?.diff
+                                        case "Void"       : flowByStatus?[.void]?.diff
+                                        default           : nil
+                                        }
+                                        if let value {
+                                            if let currency = dataManager.currencyFormat[account.currencyId] {
+                                                Text(currency.format(amount: value))
+                                                    .font(.subheadline)
+                                            } else {
+                                                Text(String(format: "%.2f", value))
+                                                    .font(.subheadline)
+                                            }
                                         }
                                     }
+                                    //.padding(.horizontal)
                                 }
-                                .padding(.horizontal)
                             }
                         }
                     }

--- a/MMEX/Views/Insights/InsightsAccountView.swift
+++ b/MMEX/Views/Insights/InsightsAccountView.swift
@@ -1,0 +1,88 @@
+//
+//  Summary.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2024/9/29.
+//
+
+import SwiftUI
+
+struct InsightsAccountInfo {
+    var dataByType: [AccountType: [AccountData]] = [:]
+    var today: String = ""
+    var flowUntilToday: [Int64: AccountFlowByStatus] = [:]
+    var flowAfterToday: [Int64: AccountFlowByStatus] = [:]
+}
+
+struct InsightsAccountView: View {
+    @EnvironmentObject var dataManager: DataManager
+    @Binding var accountInfo: InsightsAccountInfo
+    @State private var expandedSections: [AccountType: Bool] = [:]
+    
+    static let typeOrder: [AccountType] = [ .checking, .creditCard, .cash, .loan, .term, .asset, .shares ]
+
+    var body: some View {
+        VStack {
+            ForEach(Self.typeOrder) { accountType in
+                if let accounts = accountInfo.dataByType[accountType] {
+                    Section(
+                        header: HStack {
+                            Button(action: {
+                                // Toggle expanded/collapsed state
+                                expandedSections[accountType]?.toggle()
+                            }) {
+                                HStack {
+                                    Image(systemName: accountType.symbolName)
+                                        .frame(width: 5, alignment: .leading) // Adjust width as needed
+                                        .font(.system(size: 16, weight: .bold)) // Customize size and weight
+                                        .foregroundColor(.blue) // Customize icon style
+                                    Text(accountType.rawValue)
+                                        .font(.subheadline)
+                                        .padding(.leading)
+                                    
+                                    Spacer(minLength: 10)
+                                    
+                                    // Expand or collapse indicator
+                                    Image(systemName: expandedSections[accountType] == true ? "chevron.down" : "chevron.right")
+                                        .foregroundColor(.gray)
+                                }
+                            }
+                        }
+                    ) {
+                        // Show account list based on expandedSections state
+                        if expandedSections[accountType] == true {
+                            ForEach(accounts) { account in
+                                HStack {
+                                    Text(account.name)
+                                        .font(.subheadline)
+                                    
+                                    Spacer(minLength: 10)
+                                    
+                                    let flow = accountInfo.flowUntilToday[account.id]
+                                    let total = (flow?.diffTotal ?? 0.0) + account.initialBal
+                                    if let currency = dataManager.currencyFormat[account.currencyId] {
+                                        Text(currency.format(amount: total))
+                                            .font(.subheadline)
+                                    } else {
+                                        Text(String(format: "%.2f", total))
+                                            .font(.subheadline)
+                                    }
+                                }
+                                .padding(.horizontal)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            for accountType in Self.typeOrder {
+                expandedSections[accountType] = true
+            }
+        }
+    }
+}
+
+#Preview {
+    //InsightsAccountView(stats: .constant(TransactionData.sampleData))
+}

--- a/MMEX/Views/Insights/InsightsAccountView.swift
+++ b/MMEX/Views/Insights/InsightsAccountView.swift
@@ -108,7 +108,11 @@ struct InsightsAccountView: View {
                     }
                 }
             }
+            .padding(.horizontal, 8)
         }
+        .padding(.bottom, 8)
+        .background(Color(.systemGray5))
+        .cornerRadius(8)
         .onAppear {
             for accountType in Self.typeOrder {
                 expandedSections[accountType] = true
@@ -118,5 +122,8 @@ struct InsightsAccountView: View {
 }
 
 #Preview {
-    //InsightsAccountView(stats: .constant(TransactionData.sampleData))
+    InsightsAccountView(
+        accountInfo: .constant(InsightsAccountInfo()),
+        statusChoice: .constant(1)
+    )
 }

--- a/MMEX/Views/Insights/InsightsAccountView.swift
+++ b/MMEX/Views/Insights/InsightsAccountView.swift
@@ -79,21 +79,23 @@ struct InsightsAccountView: View {
                                     Spacer(minLength: 10)
                                     
                                     let flowByStatus = accountInfo.flowUntilToday[account.id]
-                                    let value: Double = switch Self.statusChoices[statusChoice].1 {
+                                    let value: Double? = switch Self.statusChoices[statusChoice].1 {
                                     case "Reconciled Balance" : (flowByStatus?.diffReconciled    ?? 0.0) + account.initialBal
                                     case "Total Balance"      : (flowByStatus?.diffTotal         ?? 0.0) + account.initialBal
-                                    case "None"               : (flowByStatus?[.none]?.diff      ?? 0.0)
-                                    case "Duplicate"          : (flowByStatus?[.duplicate]?.diff ?? 0.0)
-                                    case "Follow up"          : (flowByStatus?[.followUp]?.diff  ?? 0.0)
-                                    case "Void"               : (flowByStatus?[.void]?.diff      ?? 0.0)
-                                    default                   : 0.0
+                                    case "None"       : flowByStatus?[.none]?.diff
+                                    case "Duplicate"  : flowByStatus?[.duplicate]?.diff
+                                    case "Follow up"  : flowByStatus?[.followUp]?.diff
+                                    case "Void"       : flowByStatus?[.void]?.diff
+                                    default           : nil
                                     }
-                                    if let currency = dataManager.currencyFormat[account.currencyId] {
-                                        Text(currency.format(amount: value))
-                                            .font(.subheadline)
-                                    } else {
-                                        Text(String(format: "%.2f", value))
-                                            .font(.subheadline)
+                                    if let value {
+                                        if let currency = dataManager.currencyFormat[account.currencyId] {
+                                            Text(currency.format(amount: value))
+                                                .font(.subheadline)
+                                        } else {
+                                            Text(String(format: "%.2f", value))
+                                                .font(.subheadline)
+                                        }
                                     }
                                 }
                                 .padding(.horizontal)

--- a/MMEX/Views/Insights/InsightsSummary.swift
+++ b/MMEX/Views/Insights/InsightsSummary.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Charts
 
-struct Summary: View {
+struct InsightsSummaryView: View {
     @Binding var stats: [TransactionData]
 
     var body: some View {
@@ -27,5 +27,5 @@ struct Summary: View {
 }
 
 #Preview {
-    Summary(stats: .constant(TransactionData.sampleData))
+    InsightsSummaryView(stats: .constant(TransactionData.sampleData))
 }

--- a/MMEX/Views/Insights/InsightsView.swift
+++ b/MMEX/Views/Insights/InsightsView.swift
@@ -10,15 +10,16 @@ import Charts
 
 struct InsightsView: View {
     @ObservedObject var viewModel: InsightsViewModel
+    @State var statusChoice: Int = 0
 
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
                     Section {
-                        InsightsAccountView(accountInfo: $viewModel.accountInfo)
+                        InsightsAccountView(accountInfo: $viewModel.accountInfo, statusChoice: $statusChoice)
                     } header: {
-                        Text("Account Balance")
+                        Text(InsightsAccountView.statusChoices[statusChoice].0)
                             .font(.headline)
                             .padding(.horizontal)
                     }

--- a/MMEX/Views/Insights/InsightsView.swift
+++ b/MMEX/Views/Insights/InsightsView.swift
@@ -16,7 +16,15 @@ struct InsightsView: View {
             ScrollView {
                 VStack(spacing: 20) {
                     Section {
-                        Summary(stats: $viewModel.stats)
+                        InsightsAccountView(accountInfo: $viewModel.accountInfo)
+                    } header: {
+                        Text("Account Balance")
+                            .font(.headline)
+                            .padding(.horizontal)
+                    }
+
+                    Section {
+                        InsightsSummaryView(stats: $viewModel.stats)
                     } header: {
                         Text("Account Income Summary")
                             .font(.headline)
@@ -43,7 +51,7 @@ struct InsightsView: View {
                     }
 
                     Section {
-                        IncomeAndExpense(stats: $viewModel.recentStats)
+                        IncomeExpenseView(stats: $viewModel.recentStats)
                     } header: {
                         Text("Income vs Expense Over Time")
                             .font(.headline)


### PR DESCRIPTION
## New

- `AccountRepository.dictFlowByStatus()` returns the account inflow and outflow for each status.
- `AccountFlowByStatus` provides utility functions (e.g., calculation of reconciled and total flow).
- `InsightsAccountView` shows the total balance.

## TODO

- Add picker between total and reconciled balance (or show both).