### PR TITLE
Enum & Naming

### DIFF
--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -56,7 +56,7 @@ struct ContentView: View {
                 let insightsViewModel = InsightsViewModel(env: env)
                 let infotableViewModel = TransactionViewModel(env: env)
                 TabView(selection: $selectedTab) {
-                    checkingTab(viewModel: infotableViewModel)
+                    journalTab(viewModel: infotableViewModel)
                     insightsTab(viewModel: insightsViewModel)
                     enterTab(viewModel: infotableViewModel)
                     managementTab(viewModel: infotableViewModel)
@@ -105,14 +105,14 @@ struct ContentView: View {
         .padding()
     }
 
-    // Transaction tab
-    private func checkingTab(viewModel: TransactionViewModel) -> some View {
+    // Journal tab
+    private func journalTab(viewModel: TransactionViewModel) -> some View {
         NavigationView {
-            CheckingView(viewModel: viewModel)
+            journalView(viewModel: viewModel)
                 .navigationBarTitle("Latest Transactions", displayMode: .inline)
         }
         .tabItem {
-            env.theme.tab.iconText(icon: "list.bullet", text: "Checking")
+            env.theme.tab.iconText(icon: "list.bullet", text: "Journal")
         }
         .tag(0)
     }
@@ -245,7 +245,7 @@ struct TabContentView: View {
         return Group {
             switch selectedTab {
             case 0:
-                CheckingView(viewModel: infotableViewModel) // Summary and Edit feature
+                journalView(viewModel: infotableViewModel) // Summary and Edit feature
                     .navigationBarTitle("Latest Transactions", displayMode: .inline)
             case 1:
                 InsightsView(viewModel: InsightsViewModel(env: env))

--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -108,7 +108,7 @@ struct ContentView: View {
     // Journal tab
     private func journalTab(viewModel: TransactionViewModel) -> some View {
         NavigationView {
-            journalView(viewModel: viewModel)
+            JournalView(viewModel: viewModel)
                 .navigationBarTitle("Latest Transactions", displayMode: .inline)
         }
         .tabItem {
@@ -245,7 +245,7 @@ struct TabContentView: View {
         return Group {
             switch selectedTab {
             case 0:
-                journalView(viewModel: infotableViewModel) // Summary and Edit feature
+                JournalView(viewModel: infotableViewModel) // Summary and Edit feature
                     .navigationBarTitle("Latest Transactions", displayMode: .inline)
             case 1:
                 InsightsView(viewModel: InsightsViewModel(env: env))

--- a/MMEX/Data/TransactionData.swift
+++ b/MMEX/Data/TransactionData.swift
@@ -16,8 +16,7 @@ enum TransactionType: String, EnumCollateNoCase {
 }
 
 enum TransactionStatus: String, EnumCollateNoCase {
-    // TODO: MMEX Desktop defines "" for none
-    case none       = "N" // None
+    case none       = "" // None
     case reconciled = "R" // Reconciled
     case void       = "V" // Void
     case followUp   = "F" // Follow up
@@ -26,8 +25,7 @@ enum TransactionStatus: String, EnumCollateNoCase {
 
     var fullName: String {
         return switch self {
-        // TODO: MMEX Desktop defines "Unreconciled" for none
-        case .none       : "None"
+        case .none       : "Unreconciled"
         case .reconciled : "Reconciled"
         case .void       : "Void"
         case .followUp   : "Follow up"

--- a/MMEX/Data/TransactionData.swift
+++ b/MMEX/Data/TransactionData.swift
@@ -16,7 +16,7 @@ enum TransactionType: String, EnumCollateNoCase {
 }
 
 enum TransactionStatus: String, EnumCollateNoCase {
-    case none       = "" // None
+    case none       = "-" // None
     case reconciled = "R" // Reconciled
     case void       = "V" // Void
     case followUp   = "F" // Follow up

--- a/MMEX/Data/TransactionData.swift
+++ b/MMEX/Data/TransactionData.swift
@@ -16,7 +16,7 @@ enum TransactionType: String, EnumCollateNoCase {
 }
 
 enum TransactionStatus: String, EnumCollateNoCase {
-    case none       = "-" // None
+    case none       = "" // None
     case reconciled = "R" // Reconciled
     case void       = "V" // Void
     case followUp   = "F" // Follow up

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -87,7 +87,7 @@ struct JournalView: View {
                 // Left column (Category Icon or Category Name)
                 if let categorySymbol = CategoryData.categoryToSFSymbol[viewModel.getCategoryName(for: txn.categId)] {
                     Image(systemName: categorySymbol)
-                        .frame(width: 20, alignment: .leading) // Adjust width as needed
+                        .frame(width: 50, alignment: .leading) // Adjust width as needed
                         .font(.system(size: 16, weight: .bold)) // Customize size and weight as needed
                         .foregroundColor(.blue) // Customize icon style
                 } else {
@@ -106,7 +106,7 @@ struct JournalView: View {
                         .font(.system(size: 14))
                         .foregroundColor(.gray)
                 }
-                .frame(width: 150, alignment: .leading) // Widen middle column, ensuring enough space
+                .frame(width: 100, alignment: .leading) // Widen middle column, ensuring enough space
 
                 Spacer() // To push the amount to the right side
 

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct journalView: View {
+struct JournalView: View {
     @EnvironmentObject var env: EnvironmentManager
     @ObservedObject var viewModel: TransactionViewModel
 
@@ -196,7 +196,7 @@ struct journalView: View {
 }
 
 #Preview {
-    journalView(
+    JournalView(
         viewModel: TransactionViewModel(env: EnvironmentManager.sampleData)
     )
     .environmentObject(EnvironmentManager.sampleData)

--- a/MMEX/View/Journal/journalView.swift
+++ b/MMEX/View/Journal/journalView.swift
@@ -7,12 +7,12 @@
 
 import SwiftUI
 
-struct CheckingView: View {
+struct journalView: View {
     @EnvironmentObject var env: EnvironmentManager
     @ObservedObject var viewModel: TransactionViewModel
 
-    @State private var searchQuery: String = "" // New: Search query
-    @State private var accountId: DataId = 0 //
+    @State private var searchQuery: String = "" // Search query
+    @State private var accountId: DataId = 0
     
     var body: some View {
         NavigationStack {
@@ -52,7 +52,7 @@ struct CheckingView: View {
                     }
                 }
             }
-            .searchable(text: $searchQuery, prompt: "Search by notes") // New: Search bar
+            .searchable(text: $searchQuery, prompt: "Search") // Search bar
             .onChange(of: searchQuery) { _, query in
                 viewModel.filterTransactions(by: query)
             }
@@ -196,7 +196,7 @@ struct CheckingView: View {
 }
 
 #Preview {
-    CheckingView(
+    journalView(
         viewModel: TransactionViewModel(env: EnvironmentManager.sampleData)
     )
     .environmentObject(EnvironmentManager.sampleData)

--- a/MMEX/View/Journal/journalView.swift
+++ b/MMEX/View/Journal/journalView.swift
@@ -87,7 +87,7 @@ struct journalView: View {
                 // Left column (Category Icon or Category Name)
                 if let categorySymbol = CategoryData.categoryToSFSymbol[viewModel.getCategoryName(for: txn.categId)] {
                     Image(systemName: categorySymbol)
-                        .frame(width: 50, alignment: .leading) // Adjust width as needed
+                        .frame(width: 20, alignment: .leading) // Adjust width as needed
                         .font(.system(size: 16, weight: .bold)) // Customize size and weight as needed
                         .foregroundColor(.blue) // Customize icon style
                 } else {
@@ -106,7 +106,7 @@ struct journalView: View {
                         .font(.system(size: 14))
                         .foregroundColor(.gray)
                 }
-                .frame(width: 100, alignment: .leading) // Widen middle column, ensuring enough space
+                .frame(width: 150, alignment: .leading) // Widen middle column, ensuring enough space
 
                 Spacer() // To push the amount to the right side
 

--- a/MMEX/View/Transaction/TransactionListView.swift
+++ b/MMEX/View/Transaction/TransactionListView.swift
@@ -1,5 +1,5 @@
 //
-//  CheckingListView.swift
+//  TransactionListView.swift
 //  MMEX
 //
 //  Created by Lisheng Guan on 2024/9/10.

--- a/MMEX/ViewModel/AccountViewModel.swift
+++ b/MMEX/ViewModel/AccountViewModel.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 enum AccountGroupBy: String, RepositoryGroupByProtocol {
-    case void       = "Group:"
-    case byType     = "by Type"
-    case byCurrency = "by Currency"
-    case byStatus   = "by Status"
-    case byFavorite = "by Favorite"
+    case void       = "All" // No grouping by default
+    case byType     = "By Type"
+    case byCurrency = "By Currency"
+    case byStatus   = "By Status"
+    case byFavorite = "By Favorite"
     static let defaultValue = Self.void
 }
 


### PR DESCRIPTION
## Changes
- Updated the enum to what was suggested by @georgeef 
- Changed from 'Checking' to 'Journal' to match the aspects of a General Journal in GAAP
- Reduced padding between category icon and Payee name
- Increased padding of Payee name to display more chars
  - Tested with $XXX,XXX.XX to ensure no amount wrapping
- Updated account grouping dropdown

## Preview
### TX Status

<img width="381" alt="TX Status" src="https://github.com/user-attachments/assets/7023f5e4-2be4-47d4-95a8-fb94bbf64e66">

<img width="261" alt="TX Status" src="https://github.com/user-attachments/assets/25de4e02-160d-489f-99b6-01ea1d5b8b57">

### Padding

<img width="473" alt="TX Padding" src="https://github.com/user-attachments/assets/f84b3dd5-9857-40ee-90d8-6a9e4fcf1241">

### Account Grouping

<img width="442" alt="Account Grouping" src="https://github.com/user-attachments/assets/1f3b4f0c-e960-4698-a0dc-e6ac93d48b55">


