### PR TITLE
add sample database in memory

### DIFF
--- a/MMEX/App/MMEXApp.swift
+++ b/MMEX/App/MMEXApp.swift
@@ -16,11 +16,10 @@ let log = Logger(
 @main
 struct MMEXApp: App {
     @StateObject private var env = EnvironmentManager(withStoredDatabase: ())
-    //@StateObject private var env = EnvironmentManager(withSampleDatabaseInMemory: ())
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(env: env)
                 .environmentObject(env)
                 .onAppear {
                     let appearance: Int = UserDefaults.standard.integer(forKey: "appearance")

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -116,10 +116,10 @@
     "Copy to Clipboard" : {
 
     },
-    "Create and Use Sample Database" : {
+    "Create New Database" : {
 
     },
-    "Create New Database" : {
+    "Create Sample Database" : {
 
     },
     "Credits" : {
@@ -383,13 +383,10 @@
     "Payees" : {
 
     },
-    "Please open an existing database or create a new one to get started." : {
+    "Please open or create a database to get started." : {
 
     },
     "Privacy Policy" : {
-
-    },
-    "Re-open Database" : {
 
     },
     "Release Notes" : {
@@ -405,6 +402,9 @@
 
     },
     "Sample Database" : {
+
+    },
+    "Sample Database in Memory" : {
 
     },
     "Schema Version" : {

--- a/MMEX/View/Manage/ManageView.swift
+++ b/MMEX/View/Manage/ManageView.swift
@@ -68,7 +68,7 @@ struct ManageView: View {
                 Button(action: {
                     isDocumentPickerPresented = true
                 }) {
-                    Text("Re-open Database")
+                    Text("Open Database")
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
                 .padding()
@@ -115,7 +115,7 @@ struct ManageView: View {
         }
         .listStyle(InsetGroupedListStyle()) // Better styling for iOS
         .task {
-            await expViewModel.loadManage(env: env)
+            await expViewModel.loadManage()
         }
     }
 }
@@ -123,7 +123,7 @@ struct ManageView: View {
 #Preview {
     ManageView(
         viewModel: TransactionViewModel(env: EnvironmentManager.sampleData),
-        expViewModel: ExpRepositoryViewModel(),
+        expViewModel: ExpRepositoryViewModel(env: EnvironmentManager.sampleData),
         isDocumentPickerPresented: .constant(false),
         isNewDocumentPickerPresented: .constant(false),
         isSampleDocument: .constant(false)


### PR DESCRIPTION
Changes:
- Sample database in memory (faster startup; also useful for tests in simulator).
- Move `expViewModel` to ContentView (do not re-instantiate on tab switch).
- Unload data in `expViewModel` on database close.