### PR TITLE
refine InsightsView

### DIFF
--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -147,7 +147,7 @@ struct ContentView: View {
     private func insightsTab(viewModel: InsightsViewModel) -> some View {
         NavigationView {
             InsightsView(viewModel: viewModel)
-                .navigationBarTitle("Reports and Insights", displayMode: .inline)
+                //.navigationBarTitle("Reports and Insights", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "arrow.up.right", text: "Insights")
@@ -180,7 +180,7 @@ struct ContentView: View {
                 isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
                 isSampleDocument: $isSampleDocument
             )
-            .navigationBarTitle("Manage", displayMode: .inline)
+            //.navigationBarTitle("Manage", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "folder", text: "Manage")
@@ -192,7 +192,7 @@ struct ContentView: View {
     private func settingsTab(viewModel: TransactionViewModel) -> some View {
         NavigationView {
             SettingsView(viewModel: viewModel)
-                .navigationBarTitle("Settings", displayMode: .inline)
+                //.navigationBarTitle("Settings", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "gearshape", text: "Settings")

--- a/MMEX/View/Insights/InsightsSummary.swift
+++ b/MMEX/View/Insights/InsightsSummary.swift
@@ -9,13 +9,14 @@ import SwiftUI
 import Charts
 
 struct InsightsSummaryView: View {
+    @EnvironmentObject var env: EnvironmentManager
     @Binding var stats: [TransactionData]
 
     var body: some View {
         Chart(stats) {
             BarMark(
                 x: .value("Amount", $0.income),
-                y: .value("Account", String($0.accountId))
+                y: .value("Account", env.accountCache[$0.accountId]?.name ?? "#\($0.accountId)")
             )
             .foregroundStyle(by: .value("Status", $0.status.fullName))
         }

--- a/MMEX/View/Insights/InsightsView.swift
+++ b/MMEX/View/Insights/InsightsView.swift
@@ -12,30 +12,39 @@ struct InsightsView: View {
     @EnvironmentObject var env: EnvironmentManager
     @ObservedObject var viewModel: InsightsViewModel
     @State var statusChoice: Int = 0
-
+    @State var accountBalanceIsExpanded = true
+    @State var accountIncomeIsExpanded = true
+    @State var incomeExpenseIsExpanded = true
+    
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
-                    Section {
+                    Section(header: HStack {
+                        Button(action: { accountBalanceIsExpanded.toggle() }) {
+                            env.theme.group.view(
+                                name: { Text(InsightsAccountView.statusChoices[statusChoice].0) },
+                                isExpanded: accountBalanceIsExpanded
+                            )
+                        }
+                    } ) { if accountBalanceIsExpanded {
                         InsightsAccountView(
                             viewModel: viewModel,
                             statusChoice: $statusChoice
                         )
-                    } header: {
-                        Text(InsightsAccountView.statusChoices[statusChoice].0)
-                            .font(.headline)
-                            .padding(.horizontal)
-                    }
+                    } }
 
-                    Section {
+                    Section(header: HStack {
+                        Button(action: { accountIncomeIsExpanded.toggle() }) {
+                            env.theme.group.view(
+                                name: { Text("Account Income Summary") },
+                                isExpanded: accountIncomeIsExpanded
+                            )
+                        }
+                    } ) { if accountIncomeIsExpanded {
                         InsightsSummaryView(stats: $viewModel.stats)
-                    } header: {
-                        Text("Account Income Summary")
-                            .font(.headline)
-                            .padding(.horizontal)
-                    }
-                    
+                    } }
+
                     // Date Range Filters Section
                     Section {
                         HStack {
@@ -55,14 +64,17 @@ struct InsightsView: View {
                         .shadow(radius: 2)
                     }
 
-                    Section {
+                    Section(header: HStack {
+                        Button(action: { incomeExpenseIsExpanded.toggle() }) {
+                            env.theme.group.view(
+                                name: { Text("Income vs Expense Over Time") },
+                                isExpanded: incomeExpenseIsExpanded
+                            )
+                        }
+                    } ) { if incomeExpenseIsExpanded {
                         IncomeExpenseView(stats: $viewModel.recentStats)
-                    } header: {
-                        Text("Income vs Expense Over Time")
-                            .font(.headline)
-                            .padding(.horizontal)
-                    }
-                    
+                    } }
+
                     // Placeholder for Future Sections
                     Section {
                         VStack {

--- a/MMEX/View/Repository/RepositoryListView.swift
+++ b/MMEX/View/Repository/RepositoryListView.swift
@@ -40,7 +40,7 @@ where GroupType.MainRepository == RepositoryType,
                 Menu(content: {
                     Picker("", selection: $groupChoice) {
                         ForEach(GroupChoiceType.allCases, id: \.self) { choice in
-                            Text("\(choice.rawValue)")
+                            Text("\(choice.fullName)")
                                 .font(.subheadline)
                                 .tag(choice)
                         }
@@ -49,7 +49,7 @@ where GroupType.MainRepository == RepositoryType,
                     //.labelsHidden()
                     //.pickerStyle(MenuPickerStyle())
                 }, label: { (
-                    Text("\(groupChoice.shortName) ") +
+                    Text("\(groupChoice.rawValue) ") +
                     Text(Image(systemName: "chevron.up.chevron.down"))
                 ) } )
                 .onChange(of: groupChoice) {

--- a/MMEX/ViewModel/AccountViewModel.swift
+++ b/MMEX/ViewModel/AccountViewModel.swift
@@ -14,12 +14,12 @@ enum AccountGroupChoice: String, RepositoryGroupChoiceProtocol {
     case type       = "Type"
     case currency   = "Currency"
     case status     = "Status"
-    case attachment = "Attachment"
+    case attachment = "Att."
     static let defaultValue = Self.all
 
     static let isSingleton: Set<Self> = [.all]
-    var shortName: String {
-        switch self { case .attachment: "Att."; default: rawValue }
+    var fullName: String {
+        switch self { case .attachment: "Attachment"; default: rawValue }
     }
 }
 

--- a/MMEX/ViewModel/RepositoryLoad/RepositoryLoadGroup.swift
+++ b/MMEX/ViewModel/RepositoryLoad/RepositoryLoadGroup.swift
@@ -10,11 +10,11 @@ import SwiftUI
 protocol RepositoryGroupChoiceProtocol: EnumCollateNoCase, Hashable
 where Self.AllCases: RandomAccessCollection {
     static var isSingleton: Set<Self> { get }
-    var shortName: String { get }
+    var fullName: String { get }
 }
 
 extension RepositoryGroupChoiceProtocol {
-    var shortName: String { self.rawValue }
+    var fullName: String { self.rawValue }
 }
 
 typealias RepositoryGroupData = (name: String?, dataId: [DataId])


### PR DESCRIPTION
Removed redundant NavigationBarTitles.

@guanlisheng 
In Insights, between `Account Income Summary` and `Income vs Expense Over Time`, there is a period selector, in its own Section. Is this selector applicable only for `Income vs Expense Over Time`?  Then better to move it inside its Section.