### PR TITLE
Pascal case to match the rest of views when displaying Payee flags

### DIFF
--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -100,6 +100,9 @@
         }
       }
     },
+    "Active" : {
+
+    },
     "ACTIVE" : {
       "localizations" : {
         "it" : {
@@ -622,7 +625,7 @@
     "How to manage categories?" : {
 
     },
-    "INACTIVE" : {
+    "Inactive" : {
 
     },
     "income" : {

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -781,6 +781,9 @@
         }
       }
     },
+    "No" : {
+
+    },
     "NO" : {
       "localizations" : {
         "it" : {
@@ -1209,6 +1212,9 @@
           }
         }
       }
+    },
+    "Yes" : {
+
     },
     "YES" : {
       "localizations" : {

--- a/MMEX/View/Payee/PayeeEditView.swift
+++ b/MMEX/View/Payee/PayeeEditView.swift
@@ -33,7 +33,7 @@ struct PayeeEditView: View {
                 env.theme.field.toggle(edit, "Active") {
                     Toggle(isOn: $payee.active) { }
                 } show: {
-                    Text(payee.active ? "YES" : "NO")
+                    Text(payee.active ? "Yes" : "No")
                 }
             }
 

--- a/MMEX/View/Payee/PayeeListView.swift
+++ b/MMEX/View/Payee/PayeeListView.swift
@@ -30,7 +30,7 @@ struct PayeeListView: View {
                     HStack {
                         Text(payee.name)
                         Spacer()
-                        Text(payee.active ? "ACTIVE" : "INACTIVE")
+                        Text(payee.active ? "Active" : "Inactive")
                     }
                 }
             }


### PR DESCRIPTION
This displays the account status in Pascal case like the other views. 

<img width="439" alt="image" src="https://github.com/user-attachments/assets/50ccb135-ba88-4448-8313-9e87480b0bce">

<img width="446" alt="image" src="https://github.com/user-attachments/assets/a64cb6da-edd6-4908-8aa3-ded4918d7eb3">

<img width="395" alt="image" src="https://github.com/user-attachments/assets/9ab35e5a-d4b2-47e7-b008-bdca1c98e32b">
