### PR TITLE
refine ManageView

### DIFF
--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -238,9 +238,6 @@
     "Checking" : {
 
     },
-    "Close Database" : {
-
-    },
     "Coming soon ..." : {
 
     },
@@ -719,6 +716,9 @@
     "Manage" : {
 
     },
+    "More coming soon ..." : {
+
+    },
     "More Insights Coming Soon..." : {
 
     },
@@ -753,6 +753,7 @@
       }
     },
     "New Database" : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {
@@ -914,9 +915,6 @@
       }
     },
     "Root" : {
-
-    },
-    "Sample Database" : {
 
     },
     "Sample Database in Memory" : {

--- a/MMEX/Theme/GroupTheme.swift
+++ b/MMEX/Theme/GroupTheme.swift
@@ -28,17 +28,19 @@ extension GroupTheme {
     func view<NameView: View>(
         @ViewBuilder name nameView: @escaping () -> NameView,
         count: Int? = nil,
-        isExpanded: Bool
+        isExpanded: Bool? = nil
     ) -> some View {
         return Group {
             switch layout {
             case .foldName:
                 HStack {
-                    fold(isExpanded)
+                    if let isExpanded {
+                        fold(isExpanded)
+                    }
                     nameView()
                         .font(.headline.smallCaps())
-                        .foregroundColor(.blue)
-                        .padding(.leading)
+                        .foregroundColor(.accentColor)
+                        //.padding(.leading)
                     
                     Spacer()
                     if showCount, let count {
@@ -49,17 +51,45 @@ extension GroupTheme {
                 HStack {
                     nameView()
                         .font(.headline.smallCaps())
-                        .foregroundColor(.blue)
-                        .padding(.leading)
+                        .foregroundColor(.accentColor)
+                        //.padding(.leading)
                     
                     Spacer()
                     if showCount, let count {
                         BadgeCount(count: count)
                     }
-                    fold(isExpanded)
+                    if let isExpanded {
+                        fold(isExpanded)
+                    }
                 }
             }
         }
+    }
+
+    func section<NameView: View, Content: View>(
+        @ViewBuilder name nameView: @escaping () -> NameView,
+        count: Int? = nil,
+        isExpanded: Binding<Bool>? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        Section(header: HStack {
+            if let isExpanded {
+                Button(action: { isExpanded.wrappedValue.toggle() }) {
+                    self.view(
+                        name: nameView,
+                        count: count,
+                        isExpanded: isExpanded.wrappedValue
+                    )
+                }
+            } else {
+                self.view(
+                    name: nameView,
+                    count: count
+                )
+            }
+        } ) { if isExpanded == nil || isExpanded!.wrappedValue {
+            content()
+        } }
     }
 
     func manageItem<NameView: View, MainRepository: RepositoryProtocol>(

--- a/MMEX/View/Manage/ManageView.swift
+++ b/MMEX/View/Manage/ManageView.swift
@@ -16,16 +16,21 @@ struct ManageView: View {
     @Binding var isSampleDocument: Bool
 
     @State var auxDataIsExpanded = false
+    let group = GroupTheme(layout: .nameFold)
+    var auxCount: [Int?] {[
+        vm.currencyList.count.readyValue
+    ]}
+    var auxSum: Int? {
+        auxCount.reduce(0 as Int?, { sum, next in
+            if let sum, let next { sum + next } else { nil }
+        } )
+    }
 
     var body: some View {
         List {
-            Section(header: Text("Data")) {
-                NavigationLink(destination: CurrencyListView(vm: vm)) {
-                    env.theme.group.manageItem(
-                        name: { Text(CurrencyData.dataName.1) },
-                        count: vm.currencyList.count
-                    )
-                }
+            group.section(
+                name: { Text("Data") }
+            ) {
                 NavigationLink(destination: AccountListView(vm: vm)) {
                     env.theme.group.manageItem(
                         name: { Text(AccountData.dataName.1) },
@@ -63,86 +68,73 @@ struct ManageView: View {
                     )
                 }
             }
-            
-            Section(header: HStack {
-                Button(action: { auxDataIsExpanded.toggle() }) {
-                    env.theme.group.view(
-                        name: { Text("Auxiliary Data") },
-                        isExpanded: auxDataIsExpanded
+
+            group.section(
+                name: { Text("Auxiliary Data") },
+                count: auxSum,
+                isExpanded: $auxDataIsExpanded
+            ) {
+                NavigationLink(destination: CurrencyListView(vm: vm)) {
+                    env.theme.group.manageItem(
+                        name: { Text(CurrencyData.dataName.1) },
+                        count: vm.currencyList.count
                     )
                 }
-            } ) { if auxDataIsExpanded {
-                Text("Coming soon ...")
+                Text("More coming soon ...")
                     .foregroundColor(.accentColor)
                     .opacity(0.6)
-            } }
+            }
 
-            Section(header: Text("Database")) {
-                Button(action: {
+            group.section(
+                name: { Text("Database") }
+            ) {
+                databaseButton("Open Database", fg: .white, bg: .blue) {
                     isDocumentPickerPresented = true
-                }) {
-                    Text("Open Database")
-                        .frame(maxWidth: .infinity, alignment: .center)
                 }
-                .padding()
-                .background(Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(10)
-                .listRowInsets(.init( top: 1, leading: 2, bottom: 1, trailing: 2))
-
-                Button(action: {
+                databaseButton("New Database", fg: .white, bg: .green) {
                     isNewDocumentPickerPresented = true
                     isSampleDocument = false
-                }) {
-                    Text("New Database")
-                        .frame(maxWidth: .infinity, alignment: .center)
                 }
-                .padding()
-                .background(Color.green)
-                .foregroundColor(.white)
-                .cornerRadius(10)
-                .listRowInsets(.init( top: 1, leading: 2, bottom: 1, trailing: 2))
-
+                
                 if false {
-                    Button(action: {
+                    databaseButton("Sample Database", fg: .white, bg: .orange) {
                         isNewDocumentPickerPresented = true
                         isSampleDocument = true
-                    }) {
-                        Text("Sample Database")
-                            .frame(maxWidth: .infinity, alignment: .center)
                     }
-                    .padding()
-                    .background(Color.orange)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-                    .listRowInsets(.init( top: 1, leading: 2, bottom: 1, trailing: 2))
                 }
-
-                // Close Database Button
-                Button(action: {
-                    env.closeDatabase() // Calls method to handle closing the database
-                }) {
-                    Text("Close Database")
-                        .frame(maxWidth: .infinity, alignment: .center)
+                databaseButton("Close Database", fg: .white, bg: .red) {
+                    env.closeDatabase()
                 }
-                .padding()
-                .background(Color.red)
-                .foregroundColor(.white)
-                .cornerRadius(10)
-                .listRowInsets(.init( top: 1, leading: 2, bottom: 1, trailing: 2))
             }
 
-            Section(header: Text("Database Maintenance")) {
+            group.section(
+                name: { Text("Database Maintenance") }
+            ) {
                 Text("Coming soon ...")
                     .foregroundColor(.accentColor)
                     .opacity(0.6)
             }
-
         }
         .listStyle(InsetGroupedListStyle()) // Better styling for iOS
+        .listSectionSpacing(5)
         .task {
             await vm.loadManageList()
         }
+    }
+    
+    func databaseButton(
+        _ label: String, fg: Color, bg: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(label)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .padding()
+        .background(bg)
+        .foregroundColor(fg)
+        .cornerRadius(10)
+        .listRowInsets(.init( top: 1, leading: 2, bottom: 1, trailing: 2))
     }
 }
 


### PR DESCRIPTION
`Data -> Currencies` has been moved to `Auxiliary Data`, in order to shorten the list of `Data`. This makes access to `Database` buttons a little faster in smaller displays.

Currencies is an important repository, but it is rarely managed after the initial setup.