### PR TITLE
fix nav title

### DIFF
--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -148,7 +148,7 @@ struct ContentView: View {
     private func insightsTab(vm: ViewModel, viewModel: InsightsViewModel) -> some View {
         NavigationView {
             InsightsView(vm: vm, viewModel: viewModel)
-                //.navigationBarTitle("Reports and Insights", displayMode: .inline)
+                .navigationBarTitle("Insights", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "arrow.up.right", text: "Insights")
@@ -181,7 +181,7 @@ struct ContentView: View {
                 isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
                 isSampleDocument: $isSampleDocument
             )
-            //.navigationBarTitle("Manage", displayMode: .inline)
+            .navigationBarTitle("Manage", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "folder", text: "Manage")
@@ -193,7 +193,7 @@ struct ContentView: View {
     private func settingsTab(vm: ViewModel, viewModel: TransactionViewModel) -> some View {
         NavigationView {
             SettingsView(vm: vm, viewModel: viewModel)
-                //.navigationBarTitle("Settings", displayMode: .inline)
+                .navigationBarTitle("Settings", displayMode: .inline)
         }
         .tabItem {
             env.theme.tab.iconText(icon: "gearshape", text: "Settings")

--- a/MMEX/View/Insights/InsightsView.swift
+++ b/MMEX/View/Insights/InsightsView.swift
@@ -18,87 +18,85 @@ struct InsightsView: View {
     @State var incomeExpenseIsExpanded = true
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 20) {
-                    Section(header: HStack {
-                        Button(action: { accountBalanceIsExpanded.toggle() }) {
-                            env.theme.group.view(
-                                name: { Text(InsightsAccountView.statusChoices[statusChoice].0) },
-                                isExpanded: accountBalanceIsExpanded
-                            )
-                        }
-                    } ) { if accountBalanceIsExpanded {
-                        InsightsAccountView(
-                            vm: vm,
-                            viewModel: viewModel,
-                            statusChoice: $statusChoice
+        ScrollView {
+            VStack(spacing: 20) {
+                Section(header: HStack {
+                    Button(action: { accountBalanceIsExpanded.toggle() }) {
+                        env.theme.group.view(
+                            name: { Text(InsightsAccountView.statusChoices[statusChoice].0) },
+                            isExpanded: accountBalanceIsExpanded
                         )
-                    } }
-
-                    Section(header: HStack {
-                        Button(action: { accountIncomeIsExpanded.toggle() }) {
-                            env.theme.group.view(
-                                name: { Text("Account Income Summary") },
-                                isExpanded: accountIncomeIsExpanded
-                            )
-                        }
-                    } ) { if accountIncomeIsExpanded {
-                        InsightsSummaryView(stats: $viewModel.stats)
-                    } }
-
-                    Section(header: HStack {
-                        Button(action: { incomeExpenseIsExpanded.toggle() }) {
-                            env.theme.group.view(
-                                name: { Text("Income vs Expense Over Time") },
-                                isExpanded: incomeExpenseIsExpanded
-                            )
-                        }
-                    } ) { if incomeExpenseIsExpanded {
-                        // Date Range Filters
-                        HStack {
-                            DatePicker("Start Date", selection: $viewModel.startDate, displayedComponents: .date)
-                                .labelsHidden()
-                                .datePickerStyle(.compact)
-
-                            Spacer()
-
-                            DatePicker("End Date", selection: $viewModel.endDate, displayedComponents: .date)
-                                .labelsHidden()
-                                .datePickerStyle(.compact)
-                        }
-                        .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(10)
-                        .shadow(radius: 2)
-
-                        IncomeExpenseView(stats: $viewModel.recentStats)
-                    } }
-
-                    // Placeholder for Future Sections
-                    Section {
-                        VStack {
-                            Text("More Insights Coming Soon...")
-                                .foregroundColor(.gray)
-                                .padding()
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(10)
-                        .shadow(radius: 2)
-                    } header: {
-                        Text("Upcoming Features")
-                            .font(.headline)
-                            .padding(.horizontal)
                     }
-
+                } ) { if accountBalanceIsExpanded {
+                    InsightsAccountView(
+                        vm: vm,
+                        viewModel: viewModel,
+                        statusChoice: $statusChoice
+                    )
+                } }
+                
+                Section(header: HStack {
+                    Button(action: { accountIncomeIsExpanded.toggle() }) {
+                        env.theme.group.view(
+                            name: { Text("Account Income Summary") },
+                            isExpanded: accountIncomeIsExpanded
+                        )
+                    }
+                } ) { if accountIncomeIsExpanded {
+                    InsightsSummaryView(stats: $viewModel.stats)
+                } }
+                
+                Section(header: HStack {
+                    Button(action: { incomeExpenseIsExpanded.toggle() }) {
+                        env.theme.group.view(
+                            name: { Text("Income vs Expense Over Time") },
+                            isExpanded: incomeExpenseIsExpanded
+                        )
+                    }
+                } ) { if incomeExpenseIsExpanded {
+                    // Date Range Filters
+                    HStack {
+                        DatePicker("Start Date", selection: $viewModel.startDate, displayedComponents: .date)
+                            .labelsHidden()
+                            .datePickerStyle(.compact)
+                        
+                        Spacer()
+                        
+                        DatePicker("End Date", selection: $viewModel.endDate, displayedComponents: .date)
+                            .labelsHidden()
+                            .datePickerStyle(.compact)
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(10)
+                    .shadow(radius: 2)
+                    
+                    IncomeExpenseView(stats: $viewModel.recentStats)
+                } }
+                
+                // Placeholder for Future Sections
+                Section {
+                    VStack {
+                        Text("More Insights Coming Soon...")
+                            .foregroundColor(.gray)
+                            .padding()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(10)
+                    .shadow(radius: 2)
+                } header: {
+                    Text("Upcoming Features")
+                        .font(.headline)
+                        .padding(.horizontal)
                 }
-                .padding(.horizontal)
-                .padding(.top, 10) // Reduce the top padding for less space at the top
+                
             }
-            .navigationBarTitleDisplayMode(.inline) // Ensure title is inline to reduce top space
+            .padding(.horizontal)
+            .padding(.top, 10) // Reduce the top padding for less space at the top
         }
+        .navigationBarTitleDisplayMode(.inline) // Ensure title is inline to reduce top space
     }
 }
 

--- a/MMEX/View/Settings/SettingsThemeView.swift
+++ b/MMEX/View/Settings/SettingsThemeView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct SettingsThemeView: View {
     @EnvironmentObject var env: EnvironmentManager
 
+    @AppStorage("appearance") private var appearance: Int = UIUserInterfaceStyle.unspecified.rawValue
+
     @State private var isExpanded: [String: Bool] = [
         "Tab Icons"    : true,
         "Group Layout" : true,
@@ -22,6 +24,16 @@ struct SettingsThemeView: View {
     var body: some View {
         List {
             Section() {
+                Picker("Appearance", selection: $appearance) {
+                    Text("System").tag(UIUserInterfaceStyle.unspecified.rawValue)
+                    Text("Light").tag(UIUserInterfaceStyle.light.rawValue)
+                    Text("Dark").tag(UIUserInterfaceStyle.dark.rawValue)
+                }
+                .pickerStyle(NavigationLinkPickerStyle())
+                .onChange(of: appearance) {
+                    Appearance.apply(appearance)
+                }
+
                 HStack {
                     Text("Tab Icons")
                     Spacer()
@@ -34,9 +46,6 @@ struct SettingsThemeView: View {
 //                        env.theme.tab.layout = newChoice
 //                    }
                 }
-            }
-
-            Section() {
                 HStack {
                     Text("Show Count")
                     Spacer()
@@ -154,6 +163,19 @@ struct SettingsThemeView: View {
             }
         }
         .navigationTitle("Theme")
+        .listSectionSpacing(10)
+    }
+}
+
+enum Appearance {
+    static func apply(_ appearance: Int) {
+        //log.debug("DEBUG: appearance: \(appearance)")
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            windowScene.windows.forEach { window in
+                window.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: appearance) ?? .unspecified
+                window.reloadInputViews()
+            }
+        }
     }
 }
 

--- a/MMEX/View/Settings/SettingsView.swift
+++ b/MMEX/View/Settings/SettingsView.swift
@@ -12,7 +12,6 @@ struct SettingsView: View {
     @ObservedObject var vm: ViewModel
     @ObservedObject var viewModel: TransactionViewModel
 
-    @AppStorage("appearance") private var appearance: Int = UIUserInterfaceStyle.unspecified.rawValue
     @AppStorage("defaultPayeeSetting") private var defaultPayeeSetting: DefaultPayeeSetting = .none
     @AppStorage("defaultStatus") private var defaultStatus = TransactionStatus.defaultValue
     @AppStorage("isTrackingEnabled") private var isTrackingEnabled: Bool = false // Default is tracking disabled
@@ -22,16 +21,6 @@ struct SettingsView: View {
     var body: some View {
         List {
             Section(header: Text("App Settings")) {
-                Picker("Appearance", selection: $appearance) {
-                    Text("System").tag(UIUserInterfaceStyle.unspecified.rawValue)
-                    Text("Light").tag(UIUserInterfaceStyle.light.rawValue)
-                    Text("Dark").tag(UIUserInterfaceStyle.dark.rawValue)
-                }
-                .pickerStyle(NavigationLinkPickerStyle())
-                .onChange(of: appearance) {
-                    Appearance.apply(appearance)
-                }
-
                 NavigationLink(destination: SettingsThemeView()) {
                     Text("Theme")
                 }
@@ -128,18 +117,6 @@ struct SettingsView: View {
         }
         .onAppear() {
             // TODO
-        }
-    }
-}
-
-enum Appearance {
-    static func apply(_ appearance: Int) {
-        //log.debug("DEBUG: appearance: \(appearance)")
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-            windowScene.windows.forEach { window in
-                window.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: appearance) ?? .unspecified
-                window.reloadInputViews()
-            }
         }
     }
 }


### PR DESCRIPTION
Restore navigation title in tabs, in order to prevent scrolling into the top safe area.

In Settings, move Appearance into Theme.