### PR TITLE
load settings as vm init()

### DIFF
--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -20,7 +20,7 @@ struct ContentView: View {
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
     init(env: EnvironmentManager) {
-        log.debug("ContentView.init()")
+        log.debug("DEBUG: ContentView.init()")
         self.vm = ViewModel(env: env)
         //self._vm = StateObject(wrappedValue: RepositoryViewModel(env: env))
     }
@@ -33,6 +33,7 @@ struct ContentView: View {
                 disconnectedView
             }
         }
+
         .fileImporter(
             isPresented: $isDocumentPickerPresented,
             allowedContentTypes: [.item],
@@ -40,6 +41,7 @@ struct ContentView: View {
         ) {
             handleFileImport($0)
         }
+
         .fileExporter(
             isPresented: $isNewDocumentPickerPresented,
             document: MMEXDocument(),
@@ -48,8 +50,8 @@ struct ContentView: View {
         ) {
             handleFileExport($0)
         }
-        .autocorrectionDisabled()
 
+        .autocorrectionDisabled()
     }
 
     @ViewBuilder

--- a/MMEX/View/Settings/SettingsView.swift
+++ b/MMEX/View/Settings/SettingsView.swift
@@ -144,12 +144,22 @@ struct SettingsView: View {
         .listSectionSpacing(5)
         .padding(.top, -20)
         //.border(.red)
+
         .task {
-            log.trace("DEBUG: SettingsView.load(main=\(Thread.isMainThread))")
+            log.trace("DEBUG: SettingsView.task(main=\(Thread.isMainThread))")
             await vm.loadSettingsList()
             baseCurrencyId    = vm.infotableList.baseCurrencyId.value
             defaultAccountId  = vm.infotableList.defaultAccountId.value
         }
+
+        .refreshable {
+            log.trace("DEBUG: SettingsView.refreshable(main=\(Thread.isMainThread))")
+            vm.unloadAll()
+            await vm.loadSettingsList()
+            baseCurrencyId    = vm.infotableList.baseCurrencyId.value
+            defaultAccountId  = vm.infotableList.defaultAccountId.value
+        }
+
         .alert(isPresented: $alertIsPresented) {
             Alert(
                 title: Text("Error"),

--- a/MMEX/ViewModel/ViewModel.swift
+++ b/MMEX/ViewModel/ViewModel.swift
@@ -90,6 +90,7 @@ class ViewModel: ObservableObject {
 
     init(env: EnvironmentManager) {
         self.env = env
+        Task { await loadSettingsList() }
     }
 }
 


### PR DESCRIPTION
## Problem

In Settings view, a change in `env` (e..g, a toggle in Reuse Last Payee) creates a new `vm` which is initially empty, therefore Database Settings disappear. They appear again after switching to another view and back to Settings.

## Fix

Call `loadSettingsList()` in ViewModel init().