### PR TITLE
fix tabview

### DIFF
--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -129,8 +129,10 @@ struct ContentView: View {
     // Transaction tab
     private func journalTab() -> some View {
         NavigationView {
-            JournalView()
-                .navigationBarTitle("Latest Transactions", displayMode: .inline)
+            if selectedTab == 0 {
+                JournalView()
+                    .navigationBarTitle("Latest Transactions", displayMode: .inline)
+            }
         }
         .tabItem {
             pref.theme.tab.iconText(icon: "list.bullet", text: "Journal")
@@ -141,8 +143,10 @@ struct ContentView: View {
     // Insights tab
     private func insightsTab() -> some View {
         NavigationView {
-            InsightsView()
-                .navigationBarTitle("Insights", displayMode: .inline)
+            if selectedTab == 1 {
+                InsightsView()
+                    .navigationBarTitle("Insights", displayMode: .inline)
+            }
         }
         .tabItem {
             pref.theme.tab.iconText(icon: "arrow.up.right", text: "Insights")
@@ -154,7 +158,7 @@ struct ContentView: View {
     private func enterTab() -> some View {
         NavigationView {
             EnterView(selectedTab: $selectedTab)
-                // .navigationBarTitle("Enter Transaction", displayMode: .inline)
+            // .navigationBarTitle("Enter Transaction", displayMode: .inline)
         }
         .tabItem {
             pref.theme.tab.iconText(icon: "plus.circle", text: "Enter")
@@ -165,12 +169,14 @@ struct ContentView: View {
     // Management tab
     private func managementTab() -> some View {
         NavigationView {
-            ManageView(
-                isDocumentPickerPresented: $isDocumentPickerPresented,
-                isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
-                isSampleDocument: $isSampleDocument
-            )
-            .navigationBarTitle("Manage", displayMode: .inline)
+            if selectedTab == 3 {
+                ManageView(
+                    isDocumentPickerPresented: $isDocumentPickerPresented,
+                    isNewDocumentPickerPresented: $isNewDocumentPickerPresented,
+                    isSampleDocument: $isSampleDocument
+                )
+                .navigationBarTitle("Manage", displayMode: .inline)
+            }
         }
         .tabItem {
             pref.theme.tab.iconText(icon: "folder", text: "Manage")
@@ -181,8 +187,10 @@ struct ContentView: View {
     // Settings tab
     private func settingsTab() -> some View {
         NavigationView {
-            SettingsView()
-                .navigationBarTitle("Settings", displayMode: .inline)
+            if selectedTab == 4 {
+                SettingsView()
+                    .navigationBarTitle("Settings", displayMode: .inline)
+            }
         }
         .tabItem {
             pref.theme.tab.iconText(icon: "gearshape", text: "Settings")

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -57,7 +57,10 @@ struct JournalView: View {
                         }
                         .pickerStyle(MenuPickerStyle()) // Makes it appear as a dropdown
                         .onChange(of: accountId) {
-                            vm.loadTransactions(for: accountId)
+                            Task {
+                                let data = await vm.loadTransactions(db: vm.db, for: accountId)
+                                vm.groupTransactions(data)
+                            }
                         }
                     }
                 }
@@ -73,7 +76,10 @@ struct JournalView: View {
             if let defaultAccountId = vm.infotableList.defaultAccountId.readyValue {
                 accountId = defaultAccountId
             }
-            vm.loadTransactions(for: accountId)
+            Task {
+                let data = await vm.loadTransactions(db: vm.db, for: accountId)
+                vm.groupTransactions(data)
+            }
         }
     }
 

--- a/MMEX/View/Manage/Transaction/TransactionListView.swift
+++ b/MMEX/View/Manage/Transaction/TransactionListView.swift
@@ -129,8 +129,10 @@ struct TransactionListView: View {
     func loadSelectedTransactions() {
         let startDate = Calendar.current.date(from: DateComponents(year: selectedYear, month: 1, day: 1)) ?? Date()
         let endDate = Calendar.current.date(from: DateComponents(year: selectedYear + 1, month: 1, day: 1))?.addingTimeInterval(-1) ?? Date()
-
-        vm.loadTransactions(for: nil, startDate: startDate, endDate: endDate)
+        Task {
+            let data = await vm.loadTransactions(db: vm.db, for: nil, startDate: startDate, endDate: endDate)
+            vm.groupTransactions(data)
+        }
     }
 }
 

--- a/MMEX/ViewModel/List/TransactionList.swift
+++ b/MMEX/ViewModel/List/TransactionList.swift
@@ -32,8 +32,8 @@ extension ViewModel {
         guard transactionList.reloading() else { return }
         var ok = await withTaskGroup(of: Bool.self) { taskGroup -> Bool in
             let ok = [
-                load(pref, &taskGroup, keyPath: \Self.transactionList.data),
-                load(pref, &taskGroup, keyPath: \Self.transactionList.used),
+                //load(pref, &taskGroup, keyPath: \Self.transactionList.data),
+                //load(pref, &taskGroup, keyPath: \Self.transactionList.used),
                 // auxiliary
                 load(pref, &taskGroup, keyPath: \Self.infotableList.baseCurrencyId),
                 load(pref, &taskGroup, keyPath: \Self.infotableList.defaultAccountId),


### PR DESCRIPTION
## Problem

After the move of `TransactionViewModel` into `ViewModel`, the app became very slow.

## Possible reason

It seems that the problem is excessive view updates in `ContentView`. Any change in `@EnvironmentObject vm` seems to trigger an update in all (5) tabs under `TabView`.

## Fix

In all tabs except Enter, add a condition based on `selectedTab`.