### PR TITLE
Manage -> Category -> Symbol 

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -173,6 +173,8 @@
 		92F686442CF81FE500171A6A /* TransactionEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F686432CF81FE500171A6A /* TransactionEditView.swift */; };
 		A30061782CA3B68300011B1A /* AssetFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30061772CA3B68300011B1A /* AssetFormView.swift */; };
 		A32AAED62CC3FD23005B4AEF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = A32AAED52CC3FD23005B4AEF /* Localizable.xcstrings */; };
+		A32ED5CC2D09C33500166673 /* StoredPreferenceDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32ED5CB2D09C33500166673 /* StoredPreferenceDictionary.swift */; };
+		A32ED5CE2D09EB2C00166673 /* Name2Symbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32ED5CD2D09EB2C00166673 /* Name2Symbol.swift */; };
 		A3363EEB2C93BF62004696C7 /* CurrencyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3363EEA2C93BF62004696C7 /* CurrencyRepository.swift */; };
 		A33742882CA8E55400698466 /* IncomeExpenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742872CA8E55400698466 /* IncomeExpenseView.swift */; };
 		A337428A2CA8E72C00698466 /* InsightsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33742892CA8E72C00698466 /* InsightsSummary.swift */; };
@@ -396,6 +398,8 @@
 		92F686432CF81FE500171A6A /* TransactionEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionEditView.swift; sourceTree = "<group>"; };
 		A30061772CA3B68300011B1A /* AssetFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFormView.swift; sourceTree = "<group>"; };
 		A32AAED52CC3FD23005B4AEF /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		A32ED5CB2D09C33500166673 /* StoredPreferenceDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredPreferenceDictionary.swift; sourceTree = "<group>"; };
+		A32ED5CD2D09EB2C00166673 /* Name2Symbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Name2Symbol.swift; sourceTree = "<group>"; };
 		A3363EEA2C93BF62004696C7 /* CurrencyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyRepository.swift; sourceTree = "<group>"; };
 		A33742872CA8E55400698466 /* IncomeExpenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomeExpenseView.swift; sourceTree = "<group>"; };
 		A33742892CA8E72C00698466 /* InsightsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsSummary.swift; sourceTree = "<group>"; };
@@ -727,6 +731,8 @@
 			isa = PBXGroup;
 			children = (
 				927B12462CE6C26E00AEA52F /* StoredPreference.swift */,
+				A32ED5CB2D09C33500166673 /* StoredPreferenceDictionary.swift */,
+				A32ED5CD2D09EB2C00166673 /* Name2Symbol.swift */,
 				924352ED2CB060D80052E4BC /* Theme.swift */,
 				927B12482CE6E8B700AEA52F /* Appearance.swift */,
 				924352F12CB0A93E0052E4BC /* TabTheme.swift */,
@@ -1123,6 +1129,7 @@
 				925EAC242CDAB100003CEAB3 /* AttachmentListView.swift in Sources */,
 				A3C1424E2C8B335900D3CEC0 /* PayeeData.swift in Sources */,
 				929EF6612C9FF2FD0051A3E6 /* StockData.swift in Sources */,
+				A32ED5CE2D09EB2C00166673 /* Name2Symbol.swift in Sources */,
 				9243534D2CCD38830052E4BC /* AssetList.swift in Sources */,
 				925EAB9D2CCDD67C003CEAB3 /* CategoryGroup.swift in Sources */,
 				925EAC2B2CDAC10D003CEAB3 /* FieldGroup.swift in Sources */,
@@ -1192,6 +1199,7 @@
 				920824222CA4E67200388AB2 /* TagLinkRepository.swift in Sources */,
 				A37E7D962C9B219400B4ECFC /* InfotableRepository.swift in Sources */,
 				A3C142442C89C8FA00D3CEC0 /* AccountData.swift in Sources */,
+				A32ED5CC2D09C33500166673 /* StoredPreferenceDictionary.swift in Sources */,
 				92F6860F2CF112E200171A6A /* ReportReload.swift in Sources */,
 				A3C142AE2C9134DD00D3CEC0 /* InsightsView.swift in Sources */,
 				925EAB9B2CCDB60B003CEAB3 /* CategoryList.swift in Sources */,

--- a/MMEX/Data/CategoryData.swift
+++ b/MMEX/Data/CategoryData.swift
@@ -92,6 +92,8 @@ extension CategoryData {
         "Water": "drop.fill",
         "Water Tax": "building.columns.fill"
     ]
+
+    static let predefinedSymbols: [String] = Array(categoryToSFSymbol.values)
 }
 
 extension CategoryData {

--- a/MMEX/Preference/Name2Symbol.swift
+++ b/MMEX/Preference/Name2Symbol.swift
@@ -1,0 +1,19 @@
+//
+//  CategorySymbol.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2024/12/11.
+//
+
+import Foundation
+
+struct Name2Symbol {
+    @StoredPreferenceDictionary(key: "CategorySymbols") var category2symbol: [String: String]
+}
+
+extension Name2Symbol {
+    init(prefix: String?) {
+        /// TODO
+        category2symbol.merge(CategoryData.categoryToSFSymbol) { current, _ in current }
+    }
+}

--- a/MMEX/Preference/Preference.swift
+++ b/MMEX/Preference/Preference.swift
@@ -11,6 +11,7 @@ class Preference: ObservableObject {
     @Published var theme : Theme           = .init(prefix: "theme.")
     @Published var enter : EnterPreference = .init(prefix: "enter.")
     @Published var track : TrackPreference = .init(prefix: "track.")
+    @Published var symbol: Name2Symbol     = .init(prefix: "symbol.")
 
     static let selectedTab = 1
 }

--- a/MMEX/Preference/StoredPreferenceDictionary.swift
+++ b/MMEX/Preference/StoredPreferenceDictionary.swift
@@ -1,0 +1,47 @@
+//
+//  StoredPreferenceDictionary.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2024/12/11.
+//
+
+import Foundation
+
+@propertyWrapper
+struct StoredPreferenceDictionary {
+    private var key: String
+    private var dictionary: [String: String]
+
+    var wrappedValue: [String: String] {
+        get { dictionary }
+        set {
+            dictionary = newValue
+            save(dictionary)
+        }
+    }
+
+    var projectedValue: Self { self }
+
+    init(key: String) {
+        self.key = key
+        self.dictionary = UserDefaults.standard.dictionary(forKey: key) as? [String: String] ?? [:]
+    }
+
+    func get(forKey key: String) -> String? {
+        dictionary[key]
+    }
+
+    mutating func set(_ value: String, forKey key: String) {
+        dictionary[key] = value
+        save(dictionary)
+    }
+
+    mutating func remove(forKey key: String) {
+        dictionary.removeValue(forKey: key)
+        save(dictionary)
+    }
+
+    private func save(_ dictionary: [String: String]) {
+        UserDefaults.standard.set(dictionary, forKey: key)
+    }
+}

--- a/MMEX/Preference/Theme.swift
+++ b/MMEX/Preference/Theme.swift
@@ -12,6 +12,7 @@ struct Theme {
     @StoredPreference var appearance: Appearance = .defaultValue
     @StoredPreference var numericKeypad: BoolChoice = .boolTrue
     @StoredPreference var categoryDelimiter: String = ":"
+    @StoredPreferenceDictionary(key: "CategorySymbols") var symbols: [String: String]
 
     var tab   : TabTheme   = .init()
     var group : GroupTheme = .init()

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -86,17 +86,6 @@
         }
       }
     },
-    "About MMEX4iOS" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informazioni Su MMEX4iOS"
-          }
-        }
-      }
-    },
     "Account" : {
       "localizations" : {
         "it" : {
@@ -125,34 +114,6 @@
     },
     "Active" : {
 
-    },
-    "ACTIVE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ATTIVO"
-          }
-        }
-      }
-    },
-    "Add" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
-          }
-        }
-      }
     },
     "Add Note" : {
       "localizations" : {
@@ -217,17 +178,6 @@
     "Cash" : {
       "extractionState" : "manual"
     },
-    "Categories" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categorie"
-          }
-        }
-      }
-    },
     "Category" : {
       "localizations" : {
         "it" : {
@@ -244,17 +194,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Delimitatore Di Categoria"
-          }
-        }
-      }
-    },
-    "Category Name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome Categoria"
           }
         }
       }
@@ -292,17 +231,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ringraziamenti"
-          }
-        }
-      }
-    },
-    "Dark" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
           }
         }
       }
@@ -409,28 +337,6 @@
     "Default is 1" : {
 
     },
-    "Default Payee" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beneficiario Predefinito"
-          }
-        }
-      }
-    },
-    "Default Status" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stato Predefinito"
-          }
-        }
-      }
-    },
     "Default Transaction Status" : {
 
     },
@@ -439,17 +345,6 @@
     },
     "Delete %@" : {
 
-    },
-    "Delete Category" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimina Categoria"
-          }
-        }
-      }
     },
     "Delete Transaction" : {
       "localizations" : {
@@ -529,17 +424,6 @@
     "Enter" : {
 
     },
-    "Enter Transaction" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inserisci Transazione"
-          }
-        }
-      }
-    },
     "Error" : {
 
     },
@@ -606,17 +490,6 @@
     },
     "Help" : {
 
-    },
-    "Help / FAQ" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aiuto / FAQ"
-          }
-        }
-      }
     },
     "How to add a transaction?" : {
       "localizations" : {
@@ -724,17 +597,6 @@
     "More Insights Coming Soon..." : {
 
     },
-    "n/a" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "n.d."
-          }
-        }
-      }
-    },
     "N/A" : {
       "localizations" : {
         "it" : {
@@ -750,17 +612,6 @@
     },
     "New attachments can be created from the items that contain them." : {
 
-    },
-    "New Category" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuova Categoria"
-          }
-        }
-      }
     },
     "New Transaction" : {
       "localizations" : {
@@ -870,17 +721,6 @@
         }
       }
     },
-    "Reports and Insights" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resoconti e Approfondimenti"
-          }
-        }
-      }
-    },
     "Reuse Last Payee" : {
 
     },
@@ -892,17 +732,6 @@
     },
     "Search area" : {
 
-    },
-    "Search by name" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerca per nome"
-          }
-        }
-      }
     },
     "Search by notes" : {
       "localizations" : {
@@ -940,17 +769,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleziona Categoria"
-          }
-        }
-      }
-    },
-    "Select Currency" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona Valuta"
           }
         }
       }
@@ -1052,16 +870,8 @@
     "Support" : {
 
     },
-    "System" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema"
-          }
-        }
-      }
+    "Symbol" : {
+
     },
     "Tab Icons" : {
 

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -99,7 +99,7 @@ struct JournalView: View {
             HStack {
                 let categoryName = vm.categoryList.data.readyValue?[txn.categId]?.name
                 // Left column (Category Icon or Category Name)
-                if let categoryName, let categorySymbol = CategoryData.categoryToSFSymbol[categoryName] {
+                if let categoryName, let categorySymbol = pref.symbol.category2symbol[categoryName] {
                     Image(systemName: categorySymbol)
                         .frame(width: 50, alignment: .leading) // Adjust width as needed
                         .font(.system(size: 16, weight: .bold)) // Customize size and weight as needed

--- a/MMEX/View/Manage/Category/CategoryFormView.swift
+++ b/MMEX/View/Manage/Category/CategoryFormView.swift
@@ -61,16 +61,27 @@ struct CategoryFormView: View {
                     Text(data.active ? "Yes" : "No")
                 } )
 
-                if let categorySymbol = CategoryData.categoryToSFSymbol[data.name] {
-                    pref.theme.field.view(edit, "Category Symbol", editView: {
-                        // TODO
-                    }, showView: {
-                        Image(systemName: categorySymbol)
-                            .frame(width: 50, alignment: .leading) // Adjust width as needed
-                            .font(.system(size: 16, weight: .bold)) // Customize size and weight as needed
-                            .foregroundColor(.blue) // Customize icon style
-                    })
-                }
+                pref.theme.field.view(edit, "Category Symbol", editView: {
+                    Picker("Symbol", selection: Binding(
+                        get: { pref.symbol.category2symbol[data.name] ?? "" },
+                        set: { newValue in
+                            /// CHECK full name vs name
+                            pref.symbol.category2symbol[data.name] = newValue
+                        }
+                    )) {
+                        ForEach(CategoryData.predefinedSymbols, id: \.self) { symbol in
+                            Image(systemName: symbol)
+                            .tag(symbol)
+                        }
+                    }
+                }, showView: {
+                    /// CHECK full name vs name
+                    if let symbol = pref.symbol.category2symbol[data.name], !symbol.isEmpty {
+                        Image(systemName: symbol)
+                    } else {
+                        pref.theme.field.valueOrError("No symbol", text: nil)
+                    }
+                })
             }
         }
         .keyboardState(focus: $focus, focusState: $focusState)

--- a/MMEX/View/Manage/Category/CategoryFormView.swift
+++ b/MMEX/View/Manage/Category/CategoryFormView.swift
@@ -60,6 +60,17 @@ struct CategoryFormView: View {
                 }, showView: {
                     Text(data.active ? "Yes" : "No")
                 } )
+
+                if let categorySymbol = CategoryData.categoryToSFSymbol[data.name] {
+                    pref.theme.field.view(edit, "Category Symbol", editView: {
+                        // TODO
+                    }, showView: {
+                        Image(systemName: categorySymbol)
+                            .frame(width: 50, alignment: .leading) // Adjust width as needed
+                            .font(.system(size: 16, weight: .bold)) // Customize size and weight as needed
+                            .foregroundColor(.blue) // Customize icon style
+                    })
+                }
             }
         }
         .keyboardState(focus: $focus, focusState: $focusState)


### PR DESCRIPTION
The idea is to provide a basic management function upon `CategoryData.categoryToSFSymbol` and store the mapping (category name -> symbol) in `userDefaults`

- for display, get Symbol from `CategoryData.categoryToSFSymbo || UserDefaults.standard.dictionary`.
- for editing,  use `CategoryData.categoryToSFSymbo` as the picker data source and update category name -> symbol in `UserDefaults.standard.dictionary`
- note: the key is Name instead of ID and update category2symbol map will not impact existing data much
