### PR TITLE
Fix: use default UIKeyboardType for textPad to support non-latin lang

### DIFF
--- a/MMEX/Preference/Theme.swift
+++ b/MMEX/Preference/Theme.swift
@@ -42,6 +42,6 @@ extension Theme {
     }
 
     var textPad: UIKeyboardType {
-        .alphabet
+        .default
     }
 }


### PR DESCRIPTION

https://developer.apple.com/documentation/uikit/uikeyboardtype