### PR TITLE
fix some bugs due to typo

### DIFF
--- a/MMEX/ViewModel/Group/BudgetGroup.swift
+++ b/MMEX/ViewModel/Group/BudgetGroup.swift
@@ -52,7 +52,7 @@ extension ViewModel {
         log.trace("DEBUG: ViewModel.loadBudgetGroup(\(choice.rawValue), main=\(Thread.isMainThread))")
         
         budgetGroup.choice = choice
-        stockGroup.search = false
+        budgetGroup.search = false
         budgetGroup.groupPeriod = []
         budgetGroup.groupCategory = []
 

--- a/MMEX/ViewModel/Group/PayeeGroup.swift
+++ b/MMEX/ViewModel/Group/PayeeGroup.swift
@@ -55,7 +55,7 @@ extension ViewModel {
         log.trace("DEBUG: ViewModel.loadPayeeGroup(\(choice.rawValue), main=\(Thread.isMainThread))")
         
         payeeGroup.choice = choice
-        stockGroup.search = false
+        payeeGroup.search = false
         payeeGroup.groupCategory = []
 
         switch choice {

--- a/MMEX/ViewModel/Group/ReportGroup.swift
+++ b/MMEX/ViewModel/Group/ReportGroup.swift
@@ -47,7 +47,7 @@ extension ViewModel {
         log.trace("DEBUG: ViewModel.loadReportGroup(\(choice.rawValue), main=\(Thread.isMainThread))")
         
         reportGroup.choice = choice
-        stockGroup.search = false
+        reportGroup.search = false
         reportGroup.groupGroup = []
 
         switch choice {

--- a/MMEX/ViewModel/Group/ScheduledGroup.swift
+++ b/MMEX/ViewModel/Group/ScheduledGroup.swift
@@ -66,7 +66,7 @@ extension ViewModel {
         log.trace("DEBUG: ViewModel.loadScheduledGroup(\(choice.rawValue), main=\(Thread.isMainThread))")
         
         scheduledGroup.choice = choice
-        stockGroup.search = false
+        scheduledGroup.search = false
         scheduledGroup.groupCategory = []
 
         switch choice {

--- a/MMEX/ViewModel/Search/ReportSearch.swift
+++ b/MMEX/ViewModel/Search/ReportSearch.swift
@@ -36,7 +36,7 @@ extension ViewModel {
     }
 
     func searchReportGroup(search: ReportSearch, expand: Bool = false) {
-        if assetGroup.search { return }
+        if reportGroup.search { return }
         guard reportGroup.state == .ready else { return }
         log.trace("DEBUG: ViewModel.searchReportGroup(\(search.key), main=\(Thread.isMainThread))")
         for g in 0 ..< reportGroup.value.count {
@@ -46,6 +46,6 @@ extension ViewModel {
                 reportGroup.value[g].isExpanded = true
             }
         }
-        assetGroup.search = true
+        reportGroup.search = true
     }
 }

--- a/MMEX/ViewModel/Search/StockSearch.swift
+++ b/MMEX/ViewModel/Search/StockSearch.swift
@@ -50,6 +50,6 @@ extension ViewModel {
                 stockGroup.value[g].isExpanded = true
             }
         }
-        assetGroup.search = true
+        stockGroup.search = true
     }
 }

--- a/MMEX/ViewModel/Search/StockSearch.swift
+++ b/MMEX/ViewModel/Search/StockSearch.swift
@@ -40,7 +40,7 @@ extension ViewModel {
     }
 
     func searchStockGroup(search: StockSearch, expand: Bool = false) {
-        if assetGroup.search { return }
+        if stockGroup.search { return }
         guard stockGroup.state == .ready else { return }
         log.trace("DEBUG: ViewModel.searchStockGroup(\(search.key), main=\(Thread.isMainThread))")
         for g in 0 ..< stockGroup.value.count {


### PR DESCRIPTION
This pull request fixes incorrect references to the `search` property in various group-related methods within the `ViewModel`. Previously, some methods mistakenly set or checked the `search` state of the wrong group (e.g., `stockGroup` instead of `budgetGroup`). The updates ensure that each method correctly interacts with its respective group, improving code correctness and preventing potential logical errors.

Corrections to group `search` property usage:

* Updated `loadBudgetGroup` to set `budgetGroup.search` instead of `stockGroup.search`.
* Updated `loadPayeeGroup` to set `payeeGroup.search` instead of `stockGroup.search`.
* Updated `loadReportGroup` to set `reportGroup.search` instead of `stockGroup.search`.
* Updated `loadScheduledGroup` to set `scheduledGroup.search` instead of `stockGroup.search`.

Corrections to group search logic in search methods:

* In `searchReportGroup`, now checks and sets `reportGroup.search` instead of `assetGroup.search`. [[1]](diffhunk://#diff-525d16138d176247f949426a3192921927572ef1ec6193de0097a053c3b90bedL39-R39) [[2]](diffhunk://#diff-525d16138d176247f949426a3192921927572ef1ec6193de0097a053c3b90bedL49-R49)
* In `searchStockGroup`, now checks and sets `stockGroup.search` instead of `assetGroup.search`. [[1]](diffhunk://#diff-6f2debaf6409b0f51cf412ddd2bd63cac80b9f4dea1e5361a3bb4b45092caa94L43-R43) [[2]](diffhunk://#diff-6f2debaf6409b0f51cf412ddd2bd63cac80b9f4dea1e5361a3bb4b45092caa94L53-R53)