### PR TITLE
use debounce for journal view

### DIFF
--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -10171,7 +10171,6 @@
       }
     },
     "Search by keyword" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10257,9 +10256,6 @@
           }
         }
       }
-    },
-    "Search..." : {
-
     },
     "Select account" : {
       "localizations" : {

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -10171,6 +10171,7 @@
       }
     },
     "Search by keyword" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -10256,6 +10257,9 @@
           }
         }
       }
+    },
+    "Search..." : {
+
     },
     "Select account" : {
       "localizations" : {

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -11,7 +11,7 @@ struct JournalView: View {
     @EnvironmentObject var pref: Preference
     @EnvironmentObject var vm: ViewModel
 
-    @State private var searchQuery: String = "" // New: Search query
+    @StateObject private var debounce = RepositorySearchDebounce()
     @State private var accountId: DataId = .void
 
     var body: some View {
@@ -65,8 +65,8 @@ struct JournalView: View {
                     }
                 }
             }
-            .searchable(text: $searchQuery, prompt: "Search by keyword") // New: Search bar
-            .onChange(of: searchQuery) { _, query in
+            .searchable(text: $debounce.input, prompt: "Search...")
+            .onChange(of: debounce.output) { _, query in
                 vm.filterTransactions(by: query)
             }
         }

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -65,7 +65,7 @@ struct JournalView: View {
                     }
                 }
             }
-            .searchable(text: $debounce.input, prompt: "Search...")
+            .searchable(text: $debounce.input, prompt: "Search by keyword")
             .onChange(of: debounce.output) { _, query in
                 vm.filterTransactions(by: query)
             }


### PR DESCRIPTION
This pull request refactors the search functionality in the `JournalView` by introducing a debouncing mechanism to improve performance and user experience. Instead of filtering transactions immediately on every keystroke, the search query is now debounced, reducing unnecessary filtering operations.

**Search functionality improvements:**

* Replaced the direct `@State` search query property with a `@StateObject` called `RepositorySearchDebounce` to handle debouncing of the search input.
* Updated the `.searchable` modifier and `.onChange` handler to use the debounced `input` and `output` properties, ensuring that transaction filtering only occurs after the user has paused typing.