### PR TITLE
fix timezone issue for insights

### DIFF
--- a/MMEX/ViewModel/InsightsViewModel.swift
+++ b/MMEX/ViewModel/InsightsViewModel.swift
@@ -67,7 +67,9 @@ extension ViewModel {
     }
 
     func loadInsightsFlow() {
-        self.flow.today = String(endDate.ISO8601Format().prefix(10))
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        self.flow.today = formatter.string(from: endDate)
         let repository = AccountRepository(self.db)
         typealias A = AccountRepository
         let table = A.table


### PR DESCRIPTION
This pull request updates the way the `today` property is set in the `loadInsightsFlow` method of `InsightsViewModel`. Instead of using the `ISO8601Format` and substring, it now uses a `DateFormatter` with the format `yyyy-MM-dd` for clearer and more robust date formatting.

- Changed the assignment of `self.flow.today` in `loadInsightsFlow` to use a `DateFormatter` with the format `yyyy-MM-dd` for improved date formatting consistency.