### PR TITLE
v0.2.0, new overview tab for better uex

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -469,6 +469,11 @@
 		A3C142AB2C909C1C00D3CEC0 /* EnterFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterFormView.swift; sourceTree = "<group>"; };
 		A3C142AD2C9134DD00D3CEC0 /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A39C4EE22FE8C6E300CF8957 /* Context */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Context; sourceTree = "<group>"; };
+		A39C4EE52FE8C72900CF8957 /* Overview */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Overview; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A3C142242C89751500D3CEC0 /* Frameworks */ = {
@@ -973,6 +978,7 @@
 		A3C142292C89751500D3CEC0 /* MMEX */ = {
 			isa = PBXGroup;
 			children = (
+				A39C4EE22FE8C6E300CF8957 /* Context */,
 				92F686362CF5BECC00171A6A /* Primitive */,
 				A3C142422C89B83A00D3CEC0 /* Data */,
 				A39B1B3F2C9A6741003E5562 /* Repository */,
@@ -1034,6 +1040,7 @@
 		A3C142452C89CB1600D3CEC0 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A39C4EE52FE8C72900CF8957 /* Overview */,
 				924352F72CB2EA5C0052E4BC /* Journal */,
 				A3B51C072CA8E03100BB0681 /* Insights */,
 				924352F82CB2EAD40052E4BC /* Enter */,
@@ -1058,6 +1065,10 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A39C4EE22FE8C6E300CF8957 /* Context */,
+				A39C4EE52FE8C72900CF8957 /* Overview */,
 			);
 			name = MMEX;
 			packageProductDependencies = (
@@ -1505,7 +1516,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1528,7 +1539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.32;
+				MARKETING_VERSION = 0.2.0;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",
@@ -1553,7 +1564,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
@@ -1572,7 +1583,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.32;
+				MARKETING_VERSION = 0.2.0;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",

--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -113,8 +113,9 @@ struct ContentView: View {
             }
         } else {
             TabView(selection: $selectedTab) {
-                journalTab()
-                insightsTab()
+                overviewTab()
+                // journalTab()
+                // insightsTab()
                 enterTab()
                 manageTab()
                 settingsTab()
@@ -174,6 +175,14 @@ struct ContentView: View {
         .onAppear {
             vm.unloadAll()
         }
+    }
+
+    private func overviewTab() -> some View {
+        OverviewView()
+            .tabItem {
+                pref.theme.tab.iconText(icon: "house.fill", text: "Overview")
+            }
+            .tag(0)
     }
 
     private func journalTab() -> some View {

--- a/MMEX/App/MMEXApp.swift
+++ b/MMEX/App/MMEXApp.swift
@@ -18,6 +18,7 @@ let log = Logger(
 struct MMEXApp: App {
     @StateObject private var pref = Preference()
     @StateObject private var vm = ViewModel(withStoredDatabase: ())
+    @StateObject private var appContext = AppContext.shared
 
     func track(pref: Preference) {
         log.debug("DEBUG: MMEXApp.track()")
@@ -43,6 +44,7 @@ struct MMEXApp: App {
                 }
                 .environmentObject(pref)
                 .environmentObject(vm)
+                .environmentObject(appContext)
         }
     }
 }

--- a/MMEX/Context/AppContext.swift
+++ b/MMEX/Context/AppContext.swift
@@ -1,0 +1,121 @@
+//
+//  AppContext.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+import Combine
+
+enum DateRangePreset: String, ChoiceProtocol {
+    case today     = "Today"
+    case thisWeek  = "This Week"
+    case thisMonth = "This Month"
+    case thisYear  = "This Year"
+    case all       = "All"
+    case custom    = "Custom"
+    static let defaultValue = Self.thisMonth
+}
+
+class AppContext: ObservableObject {
+    static let shared = AppContext()
+
+    @StoredPreference(key: "app.selectedAccountId", wrappedValue: .void) private var _selectedAccountId: DataId
+    @StoredPreference(key: "app.dateRangePreset", wrappedValue: .thisMonth) private var _dateRangePreset: DateRangePreset
+    @StoredPreference(key: "app.customStartDate", wrappedValue: "") private var _customStartDate: String
+    @StoredPreference(key: "app.customEndDate", wrappedValue: "") private var _customEndDate: String
+
+    var selectedAccountId: DataId {
+        get { _selectedAccountId }
+        set {
+            if _selectedAccountId != newValue {
+                _selectedAccountId = newValue
+                objectWillChange.send()
+            }
+        }
+    }
+
+    var dateRangePreset: DateRangePreset {
+        get { _dateRangePreset }
+        set {
+            if _dateRangePreset != newValue {
+                _dateRangePreset = newValue
+                objectWillChange.send()
+            }
+        }
+    }
+
+    var customStartDate: String {
+        get { _customStartDate }
+        set {
+            if _customStartDate != newValue {
+                _customStartDate = newValue
+                objectWillChange.send()
+            }
+        }
+    }
+
+    var customEndDate: String {
+        get { _customEndDate }
+        set {
+            if _customEndDate != newValue {
+                _customEndDate = newValue
+                objectWillChange.send()
+            }
+        }
+    }
+
+    var effectiveStartDate: Date? {
+        switch dateRangePreset {
+        case .today:      return Calendar.current.startOfDay(for: Date())
+        case .thisWeek:   return Calendar.current.date(byAdding: .day, value: -7, to: Date())
+        case .thisMonth:  return Calendar.current.date(byAdding: .month, value: -1, to: Date())
+        case .thisYear:   return Calendar.current.date(byAdding: .year, value: -1, to: Date())
+        case .all:        return nil
+        case .custom:     return DateString(customStartDate).optDate
+        }
+    }
+
+    var effectiveEndDate: Date? {
+        switch dateRangePreset {
+        case .today, .thisWeek, .thisMonth, .thisYear: return Date()
+        case .all:        return nil
+        case .custom:     return DateString(customEndDate).optDate
+        }
+    }
+
+    var isAllAccounts: Bool { selectedAccountId.isVoid }
+
+    var previousPeriodStart: Date? {
+        guard let start = effectiveStartDate else { return nil }
+        switch dateRangePreset {
+        case .today:
+            return Calendar.current.date(byAdding: .day, value: -1, to: start)
+        case .thisWeek:
+            return Calendar.current.date(byAdding: .day, value: -7, to: start)
+        case .thisMonth:
+            return Calendar.current.date(byAdding: .month, value: -1, to: start)
+        case .thisYear:
+            return Calendar.current.date(byAdding: .year, value: -1, to: start)
+        default:
+            return nil
+        }
+    }
+
+    var previousPeriodEnd: Date? {
+        guard let start = previousPeriodStart else { return nil }
+        switch dateRangePreset {
+        case .today:
+            return start
+        case .thisWeek:
+            return Calendar.current.date(byAdding: .day, value: 6, to: start)
+        case .thisMonth:
+            return Calendar.current.date(byAdding: .month, value: 1, to: start)?.addingTimeInterval(-1)
+        case .thisYear:
+            return Calendar.current.date(byAdding: .year, value: 1, to: start)?.addingTimeInterval(-1)
+        default:
+            return nil
+        }
+    }
+}

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -516,6 +516,16 @@
         }
       }
     },
+    "💡 Daily avg: %@, total: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "💡 Daily avg: %1$@, total: %2$@"
+          }
+        }
+      }
+    },
     "1. Use of the App" : {
       "localizations" : {
         "cs" : {
@@ -1405,6 +1415,9 @@
           }
         }
       }
+    },
+    "All Accounts" : {
+
     },
     "All content provided by the app is owned by the app developers or its licensors. You are not allowed to copy, reproduce, or distribute any content without permission." : {
       "localizations" : {
@@ -2772,6 +2785,9 @@
         }
       }
     },
+    "Clear Filter" : {
+
+    },
     "Coming soon ..." : {
       "localizations" : {
         "cs" : {
@@ -3426,6 +3442,9 @@
           }
         }
       }
+    },
+    "Custom Range" : {
+
     },
     "Data" : {
       "localizations" : {
@@ -4132,6 +4151,7 @@
       }
     },
     "Day" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ca" : {
           "stringUnit" : {
@@ -4900,6 +4920,9 @@
         }
       }
     },
+    "Details" : {
+
+    },
     "Developed by Lisheng Guan, George Ef" : {
       "localizations" : {
         "cs" : {
@@ -5283,6 +5306,9 @@
         }
       }
     },
+    "End Dates" : {
+
+    },
     "Enter" : {
       "localizations" : {
         "cs" : {
@@ -5535,7 +5561,11 @@
         }
       }
     },
+    "Expense: %@" : {
+
+    },
     "expenses" : {
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -6810,6 +6840,7 @@
       }
     },
     "income" : {
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -6936,6 +6967,9 @@
           }
         }
       }
+    },
+    "Income: %@" : {
+
     },
     "Insights" : {
       "localizations" : {
@@ -7824,6 +7858,9 @@
         }
       }
     },
+    "Loading accounts..." : {
+
+    },
     "Loading data ..." : {
       "localizations" : {
         "cs" : {
@@ -8419,6 +8456,9 @@
         }
       }
     },
+    "Net Worth" : {
+
+    },
     "New attachments can be created from the items that contain them." : {
       "localizations" : {
         "cs" : {
@@ -8859,6 +8899,12 @@
           }
         }
       }
+    },
+    "No transactions in this period" : {
+
+    },
+    "No transactions in this period." : {
+
     },
     "Notes" : {
       "localizations" : {
@@ -9793,6 +9839,9 @@
           }
         }
       }
+    },
+    "Recent" : {
+
     },
     "Release Notes" : {
       "localizations" : {
@@ -12985,6 +13034,9 @@
         }
       }
     },
+    "Trend" : {
+
+    },
     "Twitter" : {
       "localizations" : {
         "cs" : {
@@ -13283,6 +13335,9 @@
         }
       }
     },
+    "View All (%lld)" : {
+
+    },
     "Visit Official Website" : {
       "localizations" : {
         "cs" : {
@@ -13340,6 +13395,9 @@
           }
         }
       }
+    },
+    "vs %@" : {
+
     },
     "Year" : {
       "localizations" : {

--- a/MMEX/View/Insights/IncomeExpenseView.swift
+++ b/MMEX/View/Insights/IncomeExpenseView.swift
@@ -10,43 +10,113 @@ import Charts
 
 struct IncomeExpenseView: View {
     @Binding var stats: [TransactionData]
-
+    @State private var selectedDate: String?
+    
     var body: some View {
-        Chart() {
-            ForEach(stats) { stat in
-                Plot {
-                    BarMark(
-                        x: .value("Day", stat.day),
-                        y: .value("Amount", stat.income)
+        Chart {
+            ForEach(aggregatedStats, id: \.date) { item in
+                BarMark(
+                    x: .value("Date", item.date),
+                    y: .value("Amount", item.income)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        gradient: Gradient(colors: [.green.opacity(0.4), .green.opacity(0.9)]),
+                        startPoint: .top,
+                        endPoint: .bottom
                     )
-                    // .foregroundStyle(by: .value("Status", $0.status.fullName))
-                    .foregroundStyle(.green)
-                }
-                .accessibilityLabel("income")
-                .accessibilityValue("\(stat.income)")
-            }
-
-            ForEach(stats) { stat in
-                Plot {
-                    BarMark(
-                        x: .value("Day", stat.day),
-                        y: .value("Amount", 0 - stat.expenses)
+                )
+                .cornerRadius(3)
+                .accessibilityLabel("Income: \(item.income.formatted())")
+                
+                BarMark(
+                    x: .value("Date", item.date),
+                    y: .value("Amount", -item.expense)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        gradient: Gradient(colors: [.red.opacity(0.4), .red.opacity(0.9)]),
+                        startPoint: .bottom,
+                        endPoint: .top
                     )
-                    // .foregroundStyle(by: .value("Status", $0.status.fullName))
-                    .foregroundStyle(.purple)
-                }
-                .accessibilityLabel("expenses")
-                .accessibilityValue("\(stat.expenses)")
+                )
+                .cornerRadius(3)
+                .accessibilityLabel("Expense: \(item.expense.formatted())")
             }
         }
         .chartYAxis {
-            AxisMarks(preset: .automatic, position: .leading)
+            AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
+                AxisValueLabel {
+                    if let doubleValue = value.as(Double.self) {
+                        Text(abs(doubleValue).formatted())
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.3, dash: [2]))
+                    .foregroundStyle(.gray.opacity(0.3))
+            }
         }
-        .frame(height: 300)
-        .chartYAxis(.automatic)
-        .chartXAxis(.automatic)
-        .padding(.horizontal)
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 5)) { value in
+                AxisValueLabel {
+                    if let dateString = value.as(String.self) {
+                        Text(formatDateLabel(dateString))
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.3))
+                    .foregroundStyle(.gray.opacity(0.2))
+            }
+        }
+        .chartLegend(.hidden)
+        // .animation(.easeInOut(duration: 0.3), value: stats)
+        .frame(height: 150)
+        .padding(.horizontal, 4)
+        .onTapGesture {
+            // TODO
+        }
     }
+    
+    private var aggregatedStats: [DailyIncomeExpense] {
+        let grouped = Dictionary(grouping: stats) { txn in
+            String(txn.transDate.string.prefix(10))
+        }
+        return grouped.keys.compactMap { date in
+            let dayTxns = grouped[date] ?? []
+            let income = dayTxns.filter { $0.transCode == .deposit }.reduce(0) { $0 + $1.transAmount }
+            let expense = dayTxns.filter { $0.transCode == .withdrawal }.reduce(0) { $0 + $1.transAmount }
+            return DailyIncomeExpense(date: date, income: income, expense: expense)
+        }
+        .sorted { $0.date < $1.date }
+        .suffix(14)
+    }
+    
+    private func formatDateLabel(_ dateString: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let date = formatter.date(from: dateString) {
+            if Calendar.current.isDateInToday(date) {
+                return "Today"
+            } else if Calendar.current.isDateInYesterday(date) {
+                return "Yesterday"
+            } else if Calendar.current.isDate(date, equalTo: Date(), toGranularity: .month) {
+                formatter.dateFormat = "d"
+                return formatter.string(from: date)
+            } else {
+                formatter.dateFormat = "MM/dd"
+                return formatter.string(from: date)
+            }
+        }
+        return dateString
+    }
+}
+
+struct DailyIncomeExpense {
+    let date: String
+    let income: Double
+    let expense: Double
 }
 
 #Preview {

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -12,7 +12,7 @@ struct JournalView: View {
     @EnvironmentObject var vm: ViewModel
 
     @StateObject private var debounce = RepositorySearchDebounce()
-    @State private var accountId: DataId = .void
+    @EnvironmentObject var context: AppContext
 
     var body: some View {
         NavigationStack {
@@ -39,8 +39,8 @@ struct JournalView: View {
                         let accountOrder = vm.accountList.order.readyValue,
                         let accountData  = vm.accountList.data.readyValue
                     {
-                        Picker("Select Account", selection: $accountId) {
-                            if accountId.isVoid {
+                        Picker("Select Account", selection: $context.selectedAccountId) {
+                            if context.selectedAccountId.isVoid {
                                 Text("Select Account").tag(DataId.void)
                             }
                             ForEach(accountOrder) { id in
@@ -56,9 +56,9 @@ struct JournalView: View {
                             }
                         }
                         .pickerStyle(MenuPickerStyle()) // Makes it appear as a dropdown
-                        .onChange(of: accountId) {
+                        .onChange(of: context.selectedAccountId) {
                             Task {
-                                let data = await vm.loadTransactions(db: vm.db, for: accountId)
+                                let data = await vm.loadTransactions(db: vm.db, for: context.selectedAccountId)
                                 vm.groupTransactions(data)
                             }
                         }
@@ -73,11 +73,8 @@ struct JournalView: View {
         .task {
             log.debug("DEBUG: JournalView.onAppear(main=\(Thread.isMainThread))")
             await vm.loadTransactionList(pref)
-            if let defaultAccountId = vm.infotableList.defaultAccountId.readyValue {
-                accountId = defaultAccountId
-            }
             Task {
-                let data = await vm.loadTransactions(db: vm.db, for: accountId)
+                let data = await vm.loadTransactions(db: vm.db, for: context.selectedAccountId)
                 vm.groupTransactions(data)
             }
         }
@@ -161,7 +158,7 @@ struct JournalView: View {
     func getPayeeName(for txn: TransactionData) -> String {
         // Find the payee with the given ID
         if txn.transCode == .transfer {
-            if self.accountId == txn.accountId {
+            if self.context.selectedAccountId == txn.accountId {
                 if let toAccount = vm.accountList.data.readyValue?[txn.toAccountId] {
                     return String(format: "> \(toAccount.name)")
                 }
@@ -179,7 +176,7 @@ struct JournalView: View {
     func calculateTotal(for day: String) -> String {
         let transactions = vm.txns_per_day[day] ?? []
         let totalAmount = transactions.reduce(0.0) { $0 + $1.actual }
-        let account = vm.accountList.data.readyValue?[accountId]
+        let account = vm.accountList.data.readyValue?[context.selectedAccountId]
         let formatter = vm.currencyList.info.readyValue?[account?.currencyId ?? .void]?.formatter
         return totalAmount.formatted(by: formatter)
     }

--- a/MMEX/View/Overview/FinancialSummaryCard.swift
+++ b/MMEX/View/Overview/FinancialSummaryCard.swift
@@ -1,0 +1,202 @@
+//
+//  FinancialSummaryCard.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+
+struct FinancialSummaryCard: View {
+    let netWorth: Double
+    let previousNetWorth: Double
+    let netWorthChange: Double
+    let income: Double
+    let expense: Double
+    let incomeChange: Double
+    let expenseChange: Double
+    @Binding var selectedFilter: TransactionType?
+    let formatter: CurrencyFormatter?
+    
+    @EnvironmentObject var vm: ViewModel
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            netWorthRow
+            
+            Divider()
+                .padding(.vertical, 8)
+            
+            HStack(spacing: 12) {
+                MetricCard(
+                    title: "Income",
+                    icon: "arrow.down.circle.fill",
+                    amount: income,
+                    change: incomeChange,
+                    filterType: .deposit,
+                    isSelected: selectedFilter == .deposit,
+                    formatter: formatter,
+                    onTap: { selectedFilter = (selectedFilter == .deposit ? nil : .deposit) }
+                )
+                
+                MetricCard(
+                    title: "Expense",
+                    icon: "arrow.up.circle.fill",
+                    amount: expense,
+                    change: expenseChange,
+                    filterType: .withdrawal,
+                    isSelected: selectedFilter == .withdrawal,
+                    formatter: formatter,
+                    onTap: { selectedFilter = (selectedFilter == .withdrawal ? nil : .withdrawal) }
+                )
+            }
+            
+            if !vm.overviewTransactions.isEmpty {
+                Divider()
+                    .padding(.vertical, 8)
+                
+                miniTrendChart
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemBackground))
+                .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.gray.opacity(0.1), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 8)
+    }
+    
+    // MARK: - Subviews
+    
+    private var netWorthRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Net Worth")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                
+                Text(netWorth.formatted(by: formatter))
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundColor(netWorth >= 0 ? .primary : .red)
+            }
+            
+            Spacer()
+            
+            if netWorthChange != 0 {
+                VStack(alignment: .trailing, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Image(systemName: netWorthChange >= 0 ? "arrow.up" : "arrow.down")
+                            .font(.caption)
+                        Text(String(format: "%.1f%%", abs(netWorthChange)))
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                    .foregroundColor(netWorthChange >= 0 ? .green : .red)
+                    
+                    if previousNetWorth != 0 {
+                        Text("vs \(previousNetWorth.formatted(by: formatter))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+    }
+    
+    private var miniTrendChart: some View {
+        HStack(spacing: 2) {
+            ForEach(Array(vm.overviewTransactions.prefix(30)), id: \.id) { txn in
+                let isPositive = txn.transCode == .deposit
+                let height = CGFloat(min(abs(txn.transAmount) / 100 + 2, 20))
+                Rectangle()
+                    .fill(isPositive ? Color.green : Color.red)
+                    .frame(width: 4, height: height)
+            }
+        }
+        .frame(height: 20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Metric Card (子组件)
+
+struct MetricCard: View {
+    let title: String
+    let icon: String
+    let amount: Double
+    let change: Double
+    let filterType: TransactionType?
+    let isSelected: Bool
+    let formatter: CurrencyFormatter?
+    let onTap: () -> Void
+    
+    private var amountColor: Color {
+        filterType == .deposit ? .green : .red
+    }
+    
+    private var changeColor: Color {
+        change >= 0 ? .green : .red
+    }
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: icon)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(title)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    if isSelected {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 6, height: 6)
+                    }
+                }
+                
+                HStack(alignment: .bottom, spacing: 8) {
+                    Text(amount.formatted(by: formatter))
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundColor(amountColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                    
+                    if change != 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: change >= 0 ? "arrow.up" : "arrow.down")
+                                .font(.caption2)
+                            Text(String(format: "%.1f%%", abs(change)))
+                                .font(.caption)
+                        }
+                        .foregroundColor(changeColor)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.gray.opacity(0.04))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? Color.accentColor : Color.gray.opacity(0.08), lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .scaleEffect(isSelected ? 1.02 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSelected)
+    }
+}

--- a/MMEX/View/Overview/InsightsCaptionView.swift
+++ b/MMEX/View/Overview/InsightsCaptionView.swift
@@ -1,0 +1,35 @@
+//
+//  InsightsCaptionView.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+
+struct InsightsCaptionView: View {
+    let transactions: [TransactionData]
+    
+    var body: some View {
+        if transactions.isEmpty {
+            Text("No transactions in this period.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        } else {
+            let expenseTotal = transactions.filter { $0.transCode == .withdrawal }
+                .reduce(0) { $0 + $1.transAmount }
+            let days = Calendar.current.numberOfDaysInCurrentMonth()
+            let avgDaily = expenseTotal / Double(days)
+            Text("💡 Daily avg: \(String(format: "%.1f", avgDaily)), total: \(String(format: "%.1f", expenseTotal))")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+extension Calendar {
+    func numberOfDaysInCurrentMonth() -> Int {
+        let range = range(of: .day, in: .month, for: Date())
+        return range?.count ?? 30
+    }
+}

--- a/MMEX/View/Overview/OverviewHeader.swift
+++ b/MMEX/View/Overview/OverviewHeader.swift
@@ -1,0 +1,277 @@
+//
+//  OverviewHeader.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+
+struct OverviewHeader: View {
+    @EnvironmentObject var pref: Preference
+    @EnvironmentObject var vm: ViewModel
+    @EnvironmentObject var context: AppContext
+    
+    @State private var showingCustomDatePicker = false
+    let formatter: CurrencyFormatter?
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                // 账户菜单
+                accountMenu
+                
+                Spacer()
+                
+                // 日期标题菜单
+                dateMenu
+                
+                Spacer()
+                
+                // 左右导航
+                HStack(spacing: 8) {
+                    Button(action: { stepDate(by: -1) }) {
+                        Image(systemName: "chevron.left")
+                            .font(.headline)
+                    }
+                    .buttonStyle(.plain)
+                    
+                    Button(action: { stepDate(by: 1) }) {
+                        Image(systemName: "chevron.right")
+                            .font(.headline)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            
+            // 快速预设标签
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(DateRangePreset.allCases, id: \.self) { preset in
+                        if preset != .custom && preset != .all {
+                            Button(preset.rawValue) {
+                                withAnimation {
+                                    context.dateRangePreset = preset
+                                }
+                            }
+                            .font(.caption)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(context.dateRangePreset == preset ? Color.accentColor : Color.gray.opacity(0.1))
+                            .foregroundColor(context.dateRangePreset == preset ? .white : .primary)
+                            .clipShape(Capsule())
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 4)
+            }
+        }
+        .background(Color(.systemBackground))
+        .sheet(isPresented: $showingCustomDatePicker) {
+            customDatePickerSheet
+        }
+    }
+    
+    // MARK: - Subviews
+    
+    private var accountMenu: some View {
+        Menu {
+            Button("All Accounts") {
+                context.selectedAccountId = .void
+            }
+            Divider()
+            if let accounts = vm.accountList.data.readyValue {
+                ForEach(vm.accountList.order.readyValue ?? [], id: \.self) { id in
+                    if let account = accounts[id] {
+                        Button {
+                            context.selectedAccountId = id
+                        } label: {
+                            HStack {
+                                Image(systemName: account.type.symbolName)
+                                    .frame(width: 20, alignment: .leading)
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundColor(.blue)
+                                
+                                Text(account.name)
+                                
+                                Spacer()
+                                
+                                if let balance = vm.accountBalances[id] {
+                                    Text(balance.formatted(by: formatter))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                
+                                if context.selectedAccountId == id {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption)
+                                        .foregroundColor(.accentColor)
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                HStack {
+                    Text("Loading accounts...")
+                    Spacer()
+                    ProgressView()
+                }
+                .disabled(true)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                if let account = vm.accountList.data.readyValue?[context.selectedAccountId] {
+                    Image(systemName: account.type.symbolName)
+                        .font(.subheadline)
+                        .foregroundColor(.blue)
+                } else {
+                    Image(systemName: "folder")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                
+                Text(accountDisplayName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.gray.opacity(0.08))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(Color.gray.opacity(0.15), lineWidth: 0.5)
+            )
+        }
+    }
+    
+    private var accountDisplayName: String {
+        if context.selectedAccountId.isVoid {
+            return "All"
+        } else if let account = vm.accountList.data.readyValue?[context.selectedAccountId] {
+            return account.name
+        } else {
+            return "Unknown"
+        }
+    }
+    
+    private var dateMenu: some View {
+        Menu {
+            ForEach(DateRangePreset.allCases, id: \.self) { preset in
+                if preset == .custom {
+                    Button("Custom Range") {
+                        showingCustomDatePicker = true
+                    }
+                } else {
+                    Button(preset.rawValue) {
+                        withAnimation {
+                            context.dateRangePreset = preset
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                Text(dateRangeDisplayString)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private var dateRangeDisplayString: String {
+        switch context.dateRangePreset {
+        case .today:     return "Today"
+        case .thisWeek:  return "This Week"
+        case .thisMonth: return DateFormatter.monthYear.string(from: Date())
+        case .thisYear:  return DateFormatter.year.string(from: Date())
+        case .all:       return "All Time"
+        case .custom:    return "Custom"
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func stepDate(by offset: Int) {
+        let calendar = Calendar.current
+        let currentStart = context.effectiveStartDate ?? Date()
+        let currentEnd = context.effectiveEndDate ?? Date()
+        var newStart: Date?
+        var newEnd: Date?
+        
+        switch context.dateRangePreset {
+        case .today, .thisWeek:
+            newStart = calendar.date(byAdding: .day, value: offset * 7, to: currentStart)
+            newEnd = calendar.date(byAdding: .day, value: offset * 7, to: currentEnd)
+        case .thisMonth:
+            newStart = calendar.date(byAdding: .month, value: offset, to: currentStart)
+            newEnd = calendar.date(byAdding: .month, value: offset, to: currentEnd)
+        case .thisYear:
+            newStart = calendar.date(byAdding: .year, value: offset, to: currentStart)
+            newEnd = calendar.date(byAdding: .year, value: offset, to: currentEnd)
+        default:
+            return
+        }
+        
+        guard let start = newStart, let end = newEnd else { return }
+        context.dateRangePreset = .custom
+        context.customStartDate = DateString(start).string
+        context.customEndDate = DateString(end).string
+    }
+    
+    // MARK: - Custom Date Picker Sheet
+    
+    private var customDatePickerSheet: some View {
+        NavigationView {
+            VStack {
+                DatePicker("Start Date", selection: Binding(
+                    get: { context.effectiveStartDate ?? Date() },
+                    set: { context.customStartDate = DateString($0).string }
+                ), displayedComponents: .date)
+                DatePicker("End Dates", selection: Binding(
+                    get: { context.effectiveEndDate ?? Date() },
+                    set: { context.customEndDate = DateString($0).string }
+                ), displayedComponents: .date)
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Custom Range")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        showingCustomDatePicker = false
+                        context.dateRangePreset = .custom
+                    }
+                }
+            }
+        }
+    }
+}
+
+// 扩展 DateFormatter
+extension DateFormatter {
+    static let monthYear: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        return formatter
+    }()
+    
+    static let year: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+        return formatter
+    }()
+}

--- a/MMEX/View/Overview/OverviewView.swift
+++ b/MMEX/View/Overview/OverviewView.swift
@@ -1,0 +1,111 @@
+//
+//  OverviewView.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+
+struct OverviewView: View {
+    @EnvironmentObject var pref: Preference
+    @EnvironmentObject var vm: ViewModel
+    @EnvironmentObject var context: AppContext
+    
+    @State private var selectedFilter: TransactionType? = nil
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    OverviewHeader(formatter: displayFormatter)
+                    
+                    FinancialSummaryCard(
+                        netWorth: vm.overviewNetWorth,
+                        previousNetWorth: vm.overviewPreviousNetWorth,
+                        netWorthChange: vm.overviewNetWorthChange,
+                        income: vm.overviewIncome,
+                        expense: vm.overviewExpense,
+                        incomeChange: vm.overviewIncomeChange,
+                        expenseChange: vm.overviewExpenseChange,
+                        selectedFilter: $selectedFilter,
+                        formatter: displayFormatter
+                    )
+                    
+                    Divider()
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Trend")
+                                .font(.headline)
+                            Spacer()
+                            NavigationLink("Details") {
+                                InsightsView()
+                            }
+                            .font(.subheadline)
+                        }
+                        .padding(.horizontal)
+                        
+                        IncomeExpenseView(stats: $vm.overviewTransactions)
+                            .frame(height: 150)
+                            .padding(.horizontal, 4)
+                        
+                        InsightsCaptionView(transactions: vm.overviewTransactions)
+                            .padding(.horizontal)
+                    }
+                    
+                    Divider()
+                    
+                    RecentTransactionsView(
+                        transactions: vm.overviewTransactions,
+                        selectedFilter: $selectedFilter,
+                        showAccountLabel: context.isAllAccounts,
+                        formatter: displayFormatter
+                    )
+                }
+                .padding(.vertical, 8)
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                Task {
+                    await vm.loadAccountList(pref)
+                    await vm.loadPayeeList(pref)
+                    vm.refreshOverview()
+                }
+            }
+            .onChange(of: context.selectedAccountId) { _, _ in
+                vm.refreshOverview()
+            }
+            .onChange(of: context.dateRangePreset) { _, _ in
+                vm.refreshOverview()
+            }
+            .onChange(of: context.customStartDate) { _, _ in
+                vm.refreshOverview()
+            }
+            .onChange(of: context.customEndDate) { _, _ in
+                vm.refreshOverview()
+            }
+            .onChange(of: vm.infotableList.baseCurrencyId.value) {_, _ in
+                vm.refreshOverview()
+            }
+        }
+    }
+}
+
+// OverviewView.swift
+extension OverviewView {
+    var displayFormatter: CurrencyFormatter? {
+        let currencyId: DataId
+        if context.selectedAccountId.isVoid {
+            // All Accounts → Base Currency
+            guard let baseId = vm.infotableList.baseCurrencyId.readyValue else { return nil }
+            currencyId = baseId
+        } else {
+            //
+            guard let account = vm.accountList.data.readyValue?[context.selectedAccountId] else { return nil }
+            currencyId = account.currencyId
+        }
+        return vm.currencyList.info.readyValue?[currencyId]?.formatter
+    }
+}

--- a/MMEX/View/Overview/RecentTransactionsView.swift
+++ b/MMEX/View/Overview/RecentTransactionsView.swift
@@ -1,0 +1,151 @@
+//
+//  RecentTransactionsView.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/22.
+//
+
+import SwiftUI
+
+struct RecentTransactionsView: View {
+    let transactions: [TransactionData]
+    @Binding var selectedFilter: TransactionType?
+    let showAccountLabel: Bool
+    let formatter: CurrencyFormatter?
+    
+    @EnvironmentObject var pref: Preference
+    @EnvironmentObject var vm: ViewModel
+    
+    private var filteredTransactions: [TransactionData] {
+        guard let filter = selectedFilter else {
+            return Array(transactions.sorted { $0.transDate.string > $1.transDate.string }.prefix(7))
+        }
+        return transactions.filter { $0.transCode == filter }
+            .sorted { $0.transDate.string > $1.transDate.string }
+            .prefix(7)
+            .map { $0 }
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Recent")
+                    .font(.headline)
+                Spacer()
+                if selectedFilter != nil {
+                    Button("Clear Filter") {
+                        withAnimation {
+                            selectedFilter = nil
+                        }
+                    }
+                    .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            
+            if filteredTransactions.isEmpty {
+                Text("No transactions in this period")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding()
+            } else {
+                ForEach(filteredTransactions, id: \.id) { txn in
+                    NavigationLink(
+                        destination: TransactionDetailView(txn: Binding(
+                            get: { txn },
+                            set: { _ in } // readonly
+                        ))
+                    ) {
+                        TransactionRow(
+                            txn: txn,
+                            showAccountLabel: showAccountLabel,
+                            formatter: formatter
+                        )
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 4)
+                    Divider()
+                }
+            }
+            
+            NavigationLink {
+                JournalView()
+            } label: {
+                Text("View All (\(transactions.count))")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+                    .font(.subheadline)
+            }
+        }
+    }
+}
+
+// RecentTransactionsView.swift
+
+struct TransactionRow: View {
+    let txn: TransactionData
+    let showAccountLabel: Bool
+    let formatter: CurrencyFormatter?
+
+    @EnvironmentObject var pref: Preference
+    @EnvironmentObject var vm: ViewModel
+
+    // 计算 Payee 显示名称（与 JournalView 逻辑一致）
+    private var payeeDisplayName: String {
+        if txn.transCode == .transfer {
+            // 转账：显示目标账户名（带箭头方向）
+            if let toAccount = vm.accountList.data.readyValue?[txn.toAccountId] {
+                return "> \(toAccount.name)"
+            } else {
+                return "Transfer"
+            }
+        } else {
+            // 普通交易：从 payeeList 获取名称
+            if let payee = vm.payeeList.data.readyValue?[txn.payeeId] {
+                return payee.name
+            } else {
+                return "(unknown)"
+            }
+        }
+    }
+
+    // 格式化时间（与 JournalView 一致，显示 h:mm a）
+    private func formatTime(_ dateTimeString: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        if let dateTime = formatter.date(from: dateTimeString) {
+            formatter.dateFormat = "h:mm a"
+            return formatter.string(from: dateTime)
+        }
+        return dateTimeString
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            let categoryName = vm.categoryList.data.readyValue?[txn.categId]?.name ?? ""
+            let symbol = pref.symbol.category2symbol[categoryName] ?? "tag.fill"
+            Image(systemName: symbol)
+                .frame(width: 30, alignment: .leading)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.blue)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(payeeDisplayName)
+                    .font(.system(size: 16))
+                    .lineLimit(1)
+                Text(formatTime(txn.transDate.string))
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            }
+            .frame(minWidth: 100, alignment: .leading)
+
+            Spacer()
+
+            Text(txn.transAmount.formatted(by: formatter))
+                .frame(alignment: .trailing)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(txn.transCode == .deposit ? .green : .red)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/MMEX/ViewModel/InsightsViewModel.swift
+++ b/MMEX/ViewModel/InsightsViewModel.swift
@@ -126,3 +126,89 @@ extension ViewModel {
         }
     }
 }
+
+
+extension ViewModel {
+    func refreshOverview() {
+        guard let context = AppContext.shared as? AppContext else { return }
+        
+        let accountId = context.selectedAccountId
+        let startDate = context.effectiveStartDate
+        let endDate = context.effectiveEndDate
+        
+        Task {
+            // 加载当前周期交易
+            let transactions = await loadTransactions(
+                db: db,
+                for: accountId.isVoid ? nil : accountId,
+                startDate: startDate,
+                endDate: endDate
+            )
+            
+            // 加载上一周期交易（用于对比）
+            let previousStart = context.previousPeriodStart
+            let previousEnd = context.previousPeriodEnd
+            let previousTransactions = await loadTransactions(
+                db: db,
+                for: accountId.isVoid ? nil : accountId,
+                startDate: previousStart,
+                endDate: previousEnd
+            )
+            
+            let balances = await loadAccountBalances()
+            
+            await MainActor.run {
+                self.overviewTransactions = transactions
+                self.overviewPreviousTransactions = previousTransactions
+                self.accountBalances = balances
+                calculateKPI(from: transactions, previousTransactions: previousTransactions, context: context)
+            }
+        }
+    }
+
+    private func calculateKPI(from transactions: [TransactionData], previousTransactions: [TransactionData], context: AppContext) {
+        let income = transactions.filter { $0.transCode == .deposit }.reduce(0) { $0 + $1.transAmount }
+        let expense = transactions.filter { $0.transCode == .withdrawal }.reduce(0) { $0 + $1.transAmount }
+        
+        let prevIncome = previousTransactions.filter { $0.transCode == .deposit }.reduce(0) { $0 + $1.transAmount }
+        let prevExpense = previousTransactions.filter { $0.transCode == .withdrawal }.reduce(0) { $0 + $1.transAmount }
+        
+        var netWorth: Double = 0
+        var prevNetWorth: Double = 0
+        
+        if !accountBalances.isEmpty {
+            netWorth = accountBalances.values.reduce(0, +)
+            prevNetWorth = netWorth - (income - expense - prevIncome + prevExpense)
+        } else {
+            let initialBalance = accountList.data.readyValue?.values.reduce(0) { $0 + $1.initialBal } ?? 0
+            netWorth = income - expense + initialBalance
+            prevNetWorth = prevIncome - prevExpense + initialBalance
+        }
+        
+        self.overviewIncome = income
+        self.overviewExpense = expense
+        self.overviewIncomeChange = calculateChange(current: income, previous: prevIncome)
+        self.overviewExpenseChange = calculateChange(current: expense, previous: prevExpense)
+        self.overviewNetWorth = netWorth
+        self.overviewPreviousNetWorth = prevNetWorth
+        self.overviewNetWorthChange = calculateChange(current: netWorth, previous: prevNetWorth)
+    }
+
+    private func calculateChange(current: Double, previous: Double) -> Double {
+        guard previous != 0 else { return 0 }
+        return ((current - previous) / abs(previous)) * 100
+    }
+
+    private func loadAccountBalances() async -> [DataId: Double] {
+        guard let repo = AccountRepository(db) else { return [:] }
+        var balances: [DataId: Double] = [:]
+        let today = DateString(Date()).string + "z"
+        for (id, account) in accountList.data.readyValue ?? [:] {
+            let flow = repo.dictFlowByStatus(from: AccountRepository.table, supDate: today)
+            let accountFlow = flow?[id] ?? [:]
+            let totalFlow = accountFlow.values.reduce(0) { $0 + ($1.inflow - $1.outflow) }
+            balances[id] = account.initialBal + totalFlow
+        }
+        return balances
+    }
+}

--- a/MMEX/ViewModel/ViewModel.swift
+++ b/MMEX/ViewModel/ViewModel.swift
@@ -103,6 +103,21 @@ class ViewModel: ObservableObject {
     @Published var endDate: Date = Calendar.current.startOfDay(for: Date())
     @Published var flow = InsightsFlow()
     var cancellables = Set<AnyCancellable>()
+    
+    // Overview KPI
+    @Published var overviewNetWorth: Double = 0
+    @Published var overviewIncome: Double = 0
+    @Published var overviewExpense: Double = 0
+    @Published var overviewIncomeChange: Double = 0
+    @Published var overviewExpenseChange: Double = 0
+    
+    @Published var overviewPreviousTransactions: [TransactionData] = []
+    @Published var overviewPreviousNetWorth: Double = 0
+    @Published var overviewNetWorthChange: Double = 0
+    @Published var accountBalances: [DataId: Double] = [:]
+
+    //
+    @Published var overviewTransactions: [TransactionData] = []
 
     init() {
     }


### PR DESCRIPTION
This pull request introduces a new application-wide context for managing account and date range filters, updates the main tab navigation to add an Overview tab, and includes several project configuration and localization improvements.

**Core architecture and state management:**

* Added a new `AppContext` singleton (`MMEX/Context/AppContext.swift`) to centralize and persistently manage the selected account and date range filters, including support for presets like "Today", "This Month", and custom ranges. This context is now provided to the app via SwiftUI's environment. [[1]](diffhunk://#diff-155dc125b0d6237c0c41001c96aff389a41c5702bec93641732370cb79033677R1-R121) [[2]](diffhunk://#diff-16ad68f5dd04b0b5537fdc5bc5432697979a64b784acae3191d21b151b7761c6R21) [[3]](diffhunk://#diff-16ad68f5dd04b0b5537fdc5bc5432697979a64b784acae3191d21b151b7761c6R47)

**User interface and navigation:**

* Replaced the Journal and Insights tabs with a new Overview tab in the main tab bar (`ContentView.swift`), which will serve as the new entry point for the app's main dashboard. [[1]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31L116-R118) [[2]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31R180-R187)

**Project structure and configuration:**

* Updated the Xcode project file to add synchronized root groups for `Context` and `Overview`, incremented the project version to 39, and updated the marketing version to 0.2.0. [[1]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L6-R6) [[2]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R473-R477) [[3]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R981) [[4]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R1043) [[5]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R1069-R1072) [[6]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1508-R1519) [[7]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1531-R1542) [[8]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1556-R1567) [[9]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1575-R1586)

**Localization:**

* Added and updated a large set of localization keys and strings to support new features and UI elements, including terms for date ranges, filters, account selection, and dashboard metrics. [[1]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R519-R528) [[2]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R1418-R1420) [[3]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R2787-R2789) [[4]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R3445-R3447) [[5]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R4154) [[6]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R4922-R4924) [[7]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R5308-R5310) [[8]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R5563-R5568) [[9]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R6843) [[10]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R6970-R6972) [[11]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R7860-R7862) [[12]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R8458-R8460) [[13]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R8902-R8907) [[14]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R9842-R9844) [[15]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R13036-R13038) [[16]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R13337-R13339) [[17]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R13398-R13400)