### PR TITLE
both scheduled data and enter view/form honor app context accountId

### DIFF
--- a/MMEX/App/MMEXApp.swift
+++ b/MMEX/App/MMEXApp.swift
@@ -62,6 +62,7 @@ struct MMEXPreview {
         content(Self.pref, Self.vmWithoutData)
             .environmentObject(Self.pref)
             .environmentObject(Self.vmWithoutData)
+            .environmentObject(AppContext.shared)
     }
 
     @ViewBuilder
@@ -71,5 +72,6 @@ struct MMEXPreview {
         content(Self.pref, Self.vmWithSampleData)
             .environmentObject(Self.pref)
             .environmentObject(Self.vmWithSampleData)
+            .environmentObject(AppContext.shared)
     }
 }

--- a/MMEX/View/Enter/EnterView.swift
+++ b/MMEX/View/Enter/EnterView.swift
@@ -11,6 +11,7 @@ struct EnterView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var pref: Preference
     @EnvironmentObject var vm: ViewModel
+    @EnvironmentObject var context: AppContext
     @Binding var selectedTab: Int
 
     @State private var focus = false
@@ -55,7 +56,9 @@ struct EnterView: View {
         await vm.loadEnterList(pref)
 
         if newTxn.accountId.isVoid {
-            if let defaultAccountId = vm.infotableList.defaultAccountId.readyValue {
+            if !context.selectedAccountId.isVoid {
+                newTxn.accountId = context.selectedAccountId
+            } else if let defaultAccountId = vm.infotableList.defaultAccountId.readyValue {
                 newTxn.accountId = defaultAccountId
             } else if let accountOrder = vm.accountList.order.readyValue, accountOrder.count == 1 {
                 newTxn.accountId = accountOrder[0]

--- a/MMEX/View/Overview/ScheduledOverviewView.swift
+++ b/MMEX/View/Overview/ScheduledOverviewView.swift
@@ -47,6 +47,9 @@ struct ScheduledOverviewView: View {
             let accountId = context.selectedAccountId
             viewModel.load(from: vm, accountId: accountId)
         }
+        .onChange(of: context.selectedAccountId) { _, _ in
+            viewModel.load(from: vm, accountId: context.selectedAccountId)
+        }
     }
     
     // MARK: - Subviews


### PR DESCRIPTION
This pull request introduces improvements to how the selected account is handled across views by leveraging the shared `AppContext` object. The changes ensure that the user's selected account is consistently used when entering new transactions and when viewing scheduled overviews, resulting in a more seamless and intuitive user experience.

**Context management improvements:**

* Added `@EnvironmentObject var context: AppContext` to `EnterView` to provide access to the globally selected account.

**Account selection logic updates:**

* Updated the logic in `EnterView` to prioritize `context.selectedAccountId` when setting the account for a new transaction, falling back to previous defaults only if no account is selected in the context.

**View synchronization enhancements:**

* In `ScheduledOverviewView`, added an `.onChange` handler to reload data whenever `context.selectedAccountId` changes, ensuring the view always reflects the currently selected account.