### PR TITLE
introduce JournalSplitData to enrich JournalData and its toScheduled and toTransaction

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		A3B374C72C96A27800943FDB /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = A3B374C62C96A27800943FDB /* SQLite */; };
 		A3B7D5AE2FE92B3F00F87DE0 /* ScheduledOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B7D5AD2FE92B3E00F87DE0 /* ScheduledOverviewViewModel.swift */; };
 		A3B7D5B92FE977D400F87DE0 /* ScheduledValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B7D5B82FE977CD00F87DE0 /* ScheduledValidation.swift */; };
+		A3B7D5D72FEABB6000F87DE0 /* JournalSplitData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B7D5D62FEABB6000F87DE0 /* JournalSplitData.swift */; };
 		A3C1422B2C89751500D3CEC0 /* MMEXApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C1422A2C89751500D3CEC0 /* MMEXApp.swift */; };
 		A3C1422D2C89751500D3CEC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C1422C2C89751500D3CEC0 /* ContentView.swift */; };
 		A3C1422F2C89751600D3CEC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A3C1422E2C89751600D3CEC0 /* Assets.xcassets */; };
@@ -443,6 +444,7 @@
 		A39B1B372C99A0D8003E5562 /* CurrencyListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyListView.swift; sourceTree = "<group>"; };
 		A3B7D5AD2FE92B3E00F87DE0 /* ScheduledOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledOverviewViewModel.swift; sourceTree = "<group>"; };
 		A3B7D5B82FE977CD00F87DE0 /* ScheduledValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledValidation.swift; sourceTree = "<group>"; };
+		A3B7D5D62FEABB6000F87DE0 /* JournalSplitData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalSplitData.swift; sourceTree = "<group>"; };
 		A3C142272C89751500D3CEC0 /* MMEX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MMEX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3C1422A2C89751500D3CEC0 /* MMEXApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MMEXApp.swift; sourceTree = "<group>"; };
 		A3C1422C2C89751500D3CEC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -1041,6 +1043,7 @@
 				9208240B2CA4C31B00388AB2 /* BudgetData.swift */,
 				9208240D2CA4C4FA00388AB2 /* ReportData.swift */,
 				925EABBB2CD78A65003CEAB3 /* JournalData.swift */,
+				A3B7D5D62FEABB6000F87DE0 /* JournalSplitData.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -1200,6 +1203,7 @@
 				927B12352CDE855600AEA52F /* SettingsList.swift in Sources */,
 				925EAC272CDAB134003CEAB3 /* AttachmentFormView.swift in Sources */,
 				925EAC1A2CDAA813003CEAB3 /* AttachmentList.swift in Sources */,
+				A3B7D5D72FEABB6000F87DE0 /* JournalSplitData.swift in Sources */,
 				A37E7D922C9AC60000B4ECFC /* InfoContactView.swift in Sources */,
 				9208240E2CA4C4FA00388AB2 /* ReportData.swift in Sources */,
 				92F685FB2CF0CBB800171A6A /* BudgetPeriodSearch.swift in Sources */,

--- a/MMEX/Data/JournalData.swift
+++ b/MMEX/Data/JournalData.swift
@@ -99,7 +99,7 @@ extension JournalData {
         self.splits = data.splits.map { split in
             JournalSplitData(
                 id: split.id,
-                categoryId: split.categId,
+                categId: split.categId,
                 amount: split.amount,
                 notes: split.notes
             )
@@ -127,7 +127,7 @@ extension JournalData {
         self.splits = data.splits.map { split in
             JournalSplitData(
                 id: split.id,
-                categoryId: split.categId,
+                categId: split.categId,
                 amount: split.amount,
                 notes: split.notes
             )
@@ -158,7 +158,7 @@ extension JournalData {
         self.splits = data.splits.map { split in
             JournalSplitData(
                 id: split.id,
-                categoryId: split.categId,
+                categId: split.categId,
                 amount: split.amount,
                 notes: split.notes
             )
@@ -189,7 +189,7 @@ extension JournalData {
                 TransactionSplitData(
                     id: split.id,
                     transId: transactionId, // note: transId would be override
-                    categId: split.categoryId,
+                    categId: split.categId,
                     amount: split.amount,
                     notes: split.notes
                 )
@@ -221,7 +221,7 @@ extension JournalData {
                 ScheduledSplitData(
                     id: split.id,
                     schedId: scheduledId, // note: schedId would be override
-                    categId: split.categoryId,
+                    categId: split.categId,
                     amount: split.amount,
                     notes: split.notes
                 )

--- a/MMEX/Data/JournalData.swift
+++ b/MMEX/Data/JournalData.swift
@@ -72,6 +72,8 @@ struct JournalData {
     var repeatAuto        : RepeatAuto        = .defaultValue
     var repeatType        : RepeatType        = .defaultValue
     var repeatNum         : Int               = 0
+
+    var splits: [JournalSplitData] = []
 }
 
 extension JournalData {
@@ -93,6 +95,15 @@ extension JournalData {
         self.color             = data.color
         self.lastUpdatedTime   = data.lastUpdatedTime
         self.deletedTime       = data.deletedTime
+
+        self.splits = data.splits.map { split in
+            JournalSplitData(
+                id: split.id,
+                categoryId: split.categId,
+                amount: split.amount,
+                notes: split.notes
+            )
+        }
     }
 
     init(_ data: ScheduledData, sequence: Int, at transDate: DateTimeString) {
@@ -112,6 +123,15 @@ extension JournalData {
         self.followUpId        = data.followUpId
         self.toTransAmount     = data.toTransAmount
         self.color             = data.color
+
+        self.splits = data.splits.map { split in
+            JournalSplitData(
+                id: split.id,
+                categoryId: split.categId,
+                amount: split.amount,
+                notes: split.notes
+            )
+        }
     }
 
     init(_ data: ScheduledData) {
@@ -134,6 +154,15 @@ extension JournalData {
         self.repeatAuto        = data.repeatAuto
         self.repeatType        = data.repeatType
         self.repeatNum         = data.repeatNum
+
+        self.splits = data.splits.map { split in
+            JournalSplitData(
+                id: split.id,
+                categoryId: split.categId,
+                amount: split.amount,
+                notes: split.notes
+            )
+        }
     }
 }
 
@@ -155,7 +184,16 @@ extension JournalData {
             deletedTime       : deletedTime,
             followUpId        : followUpId,
             toTransAmount     : toTransAmount,
-            color             : color
+            color             : color,
+            splits: splits.map { split in
+                TransactionSplitData(
+                    id: split.id,
+                    transId: transactionId, // note: transId would be override
+                    categId: split.categoryId,
+                    amount: split.amount,
+                    notes: split.notes
+                )
+            },
         ) : nil
     }
 
@@ -178,7 +216,16 @@ extension JournalData {
             repeatAuto        : repeatAuto,
             repeatType        : repeatType,
             repeatNum         : repeatNum,
-            color             : color
+            color             : color,
+            splits: splits.map { split in
+                ScheduledSplitData(
+                    id: split.id,
+                    schedId: scheduledId, // note: schedId would be override
+                    categId: split.categoryId,
+                    amount: split.amount,
+                    notes: split.notes
+                )
+            },
         ) : nil
     }
 }

--- a/MMEX/Data/JournalSplitData.swift
+++ b/MMEX/Data/JournalSplitData.swift
@@ -10,6 +10,4 @@ struct JournalSplitData: Identifiable, Codable {
     var categId: DataId = .void
     var amount: Double = 0.0
     var notes: String = ""
-
-    // var parentId: DataId = .void
 }

--- a/MMEX/Data/JournalSplitData.swift
+++ b/MMEX/Data/JournalSplitData.swift
@@ -1,0 +1,15 @@
+//
+//  JournalSplitData.swift
+//  MMEX
+//
+//  Created by Lisheng Guan on 2026/6/23.
+//
+
+struct JournalSplitData: Identifiable, Codable {
+    var id: DataId = .void
+    var categoryId: DataId = .void
+    var amount: Double = 0.0
+    var notes: String = ""
+
+    // var parentId: DataId = .void
+}

--- a/MMEX/Data/JournalSplitData.swift
+++ b/MMEX/Data/JournalSplitData.swift
@@ -7,7 +7,7 @@
 
 struct JournalSplitData: Identifiable, Codable {
     var id: DataId = .void
-    var categoryId: DataId = .void
+    var categId: DataId = .void
     var amount: Double = 0.0
     var notes: String = ""
 

--- a/MMEX/Data/ScheduledData.swift
+++ b/MMEX/Data/ScheduledData.swift
@@ -86,6 +86,8 @@ struct ScheduledData: DataProtocol {
     var repeatType        : RepeatType        = .defaultValue
     var repeatNum         : Int               = 0
     var color             : Int64             = 0
+
+    var splits            : [ScheduledSplitData] = []
 }
 
 extension ScheduledData {

--- a/MMEX/Repository/ScheduledRepository.swift
+++ b/MMEX/Repository/ScheduledRepository.swift
@@ -154,4 +154,14 @@ extension ScheduledRepository {
     func load() -> [ScheduledData]? {
         return select(from: Self.table)
     }
+
+    // insert with its splits
+    func insertWithSplits(_ data: inout RepositoryData) -> Bool {
+        return insert(&data) && ScheduledSplitRepository(db).update(&data)
+    }
+
+    // update with its splits
+    func updateWithSplits(_ data: inout ScheduledData) -> Bool {
+        return update(data) && ScheduledSplitRepository(db).update(&data)
+    }
 }

--- a/MMEX/Repository/ScheduledSplitRepository.swift
+++ b/MMEX/Repository/ScheduledSplitRepository.swift
@@ -91,4 +91,32 @@ extension ScheduledSplitRepository {
     func load(for sched: ScheduledData) -> [ScheduledSplitData]? {
         return load(forScheduledId: sched.id)
     }
+
+    func delete(_ trans: ScheduledData) -> Bool {
+        let splits = load(for: trans)
+        guard let splits else { return false }
+        var success = true
+        splits.forEach { split in
+            success = success && delete(split)
+        }
+        return success
+    }
+
+    // FIXME: delete all old splits for the given transaction and then re-create all splits
+    func update(_ trans: inout ScheduledData) -> Bool {
+        let splits = load(for: trans)
+        guard let splits else { return false }
+        var success = true
+
+        // TODO: distintish to add/update/delete
+        splits.forEach { split in
+            success = success && delete(split)
+        }
+
+        for i in trans.splits.indices {
+            trans.splits[i].schedId = trans.id
+            success = success && insert(&trans.splits[i])
+        }
+        return success
+    }
 }


### PR DESCRIPTION
This pull request introduces support for handling split data in journal transactions by adding a new `JournalSplitData` struct and integrating it into the existing `JournalData` structure. The changes ensure that split information is properly mapped, stored, and converted between related data types. Additionally, the Xcode project file is updated to include the new source file.

**Support for split data in journal transactions:**

* Added a new `JournalSplitData` struct to represent split line items within a journal transaction (`MMEX/Data/JournalSplitData.swift`).
* Updated `JournalData` to include a `splits` property, and added logic to map split data when initializing from related data types (`MMEX/Data/JournalData.swift`). [[1]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795R75-R76) [[2]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795R98-R106) [[3]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795R126-R134) [[4]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795R157-R165)
* Modified conversion methods in `JournalData` to correctly map splits to `TransactionSplitData` and `ScheduledSplitData` as appropriate (`MMEX/Data/JournalData.swift`). [[1]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795L158-R196) [[2]](diffhunk://#diff-4746a1ebf1878debe772311245c3ed07f1a354e30b5586fb704c65cc492cb795L181-R228)

**Project file updates:**

* Added `JournalSplitData.swift` to the Xcode project, ensuring it is included in the source build and file references (`MMEX.xcodeproj/project.pbxproj`). [[1]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R213) [[2]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R447) [[3]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R1046) [[4]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360R1206)

**Related data structure update:**

* Added a `splits` property to `ScheduledData` to maintain consistency with the new split handling (`MMEX/Data/ScheduledData.swift`).