### PR TITLE
refine recent transaction to show full date

### DIFF
--- a/MMEX/View/Overview/RecentTransactionsView.swift
+++ b/MMEX/View/Overview/RecentTransactionsView.swift
@@ -116,7 +116,7 @@ struct TransactionRow: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         if let dateTime = formatter.date(from: dateTimeString) {
-            formatter.dateFormat = "h:mm a"
+            formatter.dateFormat = "yyyy-MM-dd h:mm a"
             return formatter.string(from: dateTime)
         }
         return dateTimeString
@@ -138,8 +138,9 @@ struct TransactionRow: View {
                 Text(formatTime(journal.transDate.string))
                     .font(.system(size: 14))
                     .foregroundColor(.gray)
+                    .lineLimit(1)
             }
-            .frame(minWidth: 100, alignment: .leading)
+            .frame(minWidth: 150, alignment: .leading)
 
             Spacer()
 


### PR DESCRIPTION
This pull request makes small improvements to the `TransactionRow` view in `RecentTransactionsView.swift`, focusing on how transaction dates are displayed and improving layout consistency.

- **Date and Time Formatting:**
  - Updated the `formatTime` function to display both the date and time in the format `yyyy-MM-dd h:mm a` instead of just the time, providing more context for each transaction.

- **UI and Layout Enhancements:**
  - Added a one-line text limit to the transaction date display to prevent overflow and ensure a cleaner UI.
  - Increased the minimum width of the date display frame from 100 to 150 for better alignment and readability.