### PR TITLE
fix make as paid bug

### DIFF
--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -8229,9 +8229,6 @@
         }
       }
     },
-    "Mark Paid" : {
-
-    },
     "MMEX4iOS" : {
       "localizations" : {
         "cs" : {

--- a/MMEX/View/Manage/Transaction/TransactionDetailView.swift
+++ b/MMEX/View/Manage/Transaction/TransactionDetailView.swift
@@ -77,18 +77,6 @@ struct TransactionDetailView: View {
                             Text(journal.repeatNum == -1 ? "Infinite" : "\(journal.repeatNum)")
                         }
                     }
-                    // Action buttons (only if not void?)
-                    HStack {
-                        Button("Skip") {
-                            // Implement skip logic (update nextDueDate)
-                        }
-                        .buttonStyle(.bordered)
-                        Button("Mark Paid") {
-                            // Create a transaction from this scheduled entry and advance due date
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.green)
-                    }
                 }
             }
 

--- a/MMEX/ViewModel/ScheduledOverviewViewModel.swift
+++ b/MMEX/ViewModel/ScheduledOverviewViewModel.swift
@@ -98,10 +98,34 @@ class ScheduledOverviewViewModel: ObservableObject {
         }
         
         guard let nextDate = item.scheduled.nextDueDate(from: item.nextDueDate) else {
-            return true
+            var completed = item.scheduled
+            completed.status = .void
+            completed.repeatAuto = .none
+            completed.repeatType = .once
+            completed.repeatNum = 0
+
+            return updateScheduled(completed, in: vm)
         }
         var updated = item.scheduled
         updated.dueDate = DateString(nextDate)
+
+        if let typeNum = item.scheduled.repeatTypeNum {
+            switch typeNum {
+            case .times(let type, let remaining):
+                if remaining.value > 1 {
+                    updated.repeatNum = remaining.value - 1
+                    updated.repeatType = type
+                } else {
+                    updated.status = .void
+                    updated.repeatAuto = .none
+                    updated.repeatType = .once
+                    updated.repeatNum = 0
+                }
+            default:
+                break
+            }
+        }
+
         return updateScheduled(updated, in: vm)
     }
     
@@ -119,7 +143,7 @@ class ScheduledOverviewViewModel: ObservableObject {
             payeeId: scheduled.payeeId,
             transCode: scheduled.transCode,
             transAmount: scheduled.transAmount,
-            status: .reconciled,
+            status: scheduled.status,
             transactionNumber: scheduled.transactionNumber,
             notes: scheduled.notes,
             categId: scheduled.categId,
@@ -143,7 +167,7 @@ class ScheduledOverviewViewModel: ObservableObject {
         
         guard let repo = TransactionRepository(vm.db) else { return false }
         var txn = transaction
-        return repo.insert(&txn)
+        return repo.insertWithSplits(&txn)
     }
 }
 


### PR DESCRIPTION
This pull request refines the scheduled transaction logic by improving how scheduled entries are updated and processed, and by removing unused UI elements. The most important changes focus on better handling of recurring transactions, ensuring correct status updates, and cleaning up the user interface.

### Scheduled transaction logic improvements

* Enhanced the logic for updating scheduled transactions: when a scheduled transaction has no further due dates, it is now properly marked as void and its repeat settings are cleared. The repeat count is also decremented correctly when applicable.
* When creating a transaction from a scheduled entry, the transaction now inherits the scheduled entry's status instead of always being marked as reconciled.
* Transactions are now inserted using the `insertWithSplits` method, ensuring that split transactions are handled correctly.

### UI cleanup

* Removed the "Skip" and "Mark Paid" action buttons from `TransactionDetailView`, as their logic is either not implemented or has been refactored elsewhere.

### Localization cleanup

* Removed the unused "Mark Paid" string entry from the localization file `Localizable.xcstrings`.