### PR TITLE
v0.2.2(41)

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -1539,7 +1539,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1562,7 +1562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",
@@ -1587,7 +1587,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
@@ -1606,7 +1606,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",


### PR DESCRIPTION
This pull request updates the project versioning information in the Xcode project configuration. The changes are minor and primarily focused on incrementing version numbers.

- Incremented `CURRENT_PROJECT_VERSION` from 40 to 41 to reflect a new internal build version. [[1]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1542-R1542) [[2]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1590-R1590)
- Updated `MARKETING_VERSION` from 0.2.1 to 0.2.2 to indicate a new public release version. [[1]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1565-R1565) [[2]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1609-R1609)