### PR TITLE
feat: create account/category/payee from enter view

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -1539,7 +1539,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1562,7 +1562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",
@@ -1587,7 +1587,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
@@ -1606,7 +1606,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -3172,6 +3172,12 @@
         }
       }
     },
+    "Create Account" : {
+
+    },
+    "Create Category" : {
+
+    },
     "Create New Database" : {
       "localizations" : {
         "cs" : {
@@ -3229,6 +3235,9 @@
           }
         }
       }
+    },
+    "Create Payee" : {
+
     },
     "Create Sample Database" : {
       "localizations" : {
@@ -8286,6 +8295,9 @@
           }
         }
       }
+    },
+    "More create actions" : {
+
     },
     "More Insights Coming Soon..." : {
       "localizations" : {

--- a/MMEX/View/Enter/EnterFormView.swift
+++ b/MMEX/View/Enter/EnterFormView.swift
@@ -414,7 +414,6 @@ struct EnterFormView: View {
     }
 
     private func prepareCreateAccount() {
-        createAccountTarget = .account
         var data = AccountListView.initData
         data.currencyId = vm.accountList.data.readyValue?[journal.accountId]?.currencyId
             ?? vm.accountList.order.readyValue?.first.flatMap { vm.accountList.data.readyValue?[$0]?.currencyId }

--- a/MMEX/View/Enter/EnterFormView.swift
+++ b/MMEX/View/Enter/EnterFormView.swift
@@ -8,11 +8,6 @@
 import SwiftUI
 
 struct EnterFormView: View {
-    private enum AccountSelectionTarget {
-        case account
-        case toAccount
-    }
-
     @EnvironmentObject var pref: Preference
     @EnvironmentObject var vm: ViewModel
     @Binding var focus: Bool
@@ -35,8 +30,6 @@ struct EnterFormView: View {
     @State private var newAccountData: AccountData? = nil
     @State private var newPayeeData: PayeeData? = nil
     @State private var newCategoryData: CategoryData? = nil
-
-    @State private var createAccountTarget: AccountSelectionTarget = .account
 
     var body: some View {
         VStack {
@@ -349,12 +342,7 @@ struct EnterFormView: View {
                 guard let created = newAccountData else { return }
                 Task { @MainActor in
                     await vm.reloadAccount(pref, nil as AccountData?, created)
-                    switch createAccountTarget {
-                    case .account:
-                        journal.accountId = created.id
-                    case .toAccount:
-                        journal.toAccountId = created.id
-                    }
+                    journal.accountId = created.id
                     newAccountData = nil
                 }
             }

--- a/MMEX/View/Enter/EnterFormView.swift
+++ b/MMEX/View/Enter/EnterFormView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct EnterFormView: View {
+    private enum AccountSelectionTarget {
+        case account
+        case toAccount
+    }
+
     @EnvironmentObject var pref: Preference
     @EnvironmentObject var vm: ViewModel
     @Binding var focus: Bool
@@ -18,6 +23,20 @@ struct EnterFormView: View {
     @State private var editSplitData = JournalSplitData()
     @State private var editingSplitIndex: Int? = nil
     @State private var showingSplitEditor = false
+
+    @State private var showingCreateAccount = false
+    @State private var showingCreatePayee = false
+    @State private var showingCreateCategory = false
+
+    @State private var createAccountData = AccountListView.initData
+    @State private var createPayeeData = PayeeListView.initData
+    @State private var createCategoryData = CategoryListView.initData
+
+    @State private var newAccountData: AccountData? = nil
+    @State private var newPayeeData: PayeeData? = nil
+    @State private var newCategoryData: CategoryData? = nil
+
+    @State private var createAccountTarget: AccountSelectionTarget = .account
 
     var body: some View {
         VStack {
@@ -43,13 +62,15 @@ struct EnterFormView: View {
 
                 Spacer()
 
-                Picker("Select account", selection: $journal.accountId) {
-                    if (journal.accountId.isVoid) {
-                        Text("Account:").tag(DataId.void)
-                    }
-                    ForEach(vm.accountList.order.readyValue ?? [], id: \.self) { id in
-                        if let account = vm.accountList.data.readyValue?[id] {
-                            Text(account.name).tag(id)
+                HStack(spacing: 6) {
+                    Picker("Select account", selection: $journal.accountId) {
+                        if (journal.accountId.isVoid) {
+                            Text("Account:").tag(DataId.void)
+                        }
+                        ForEach(vm.accountList.order.readyValue ?? [], id: \.self) { id in
+                            if let account = vm.accountList.data.readyValue?[id] {
+                                Text(account.name).tag(id)
+                            }
                         }
                     }
                 }
@@ -273,6 +294,33 @@ struct EnterFormView: View {
         }
         .keyboardState(focus: $focus, focusState: $focusState)
         .padding(.horizontal)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Button {
+                        prepareCreateAccount()
+                    } label: {
+                        Label("Create Account", systemImage: "plus")
+                    }
+
+                    Button {
+                        prepareCreatePayee()
+                    } label: {
+                        Label("Create Payee", systemImage: "plus")
+                    }
+
+                    Button {
+                        prepareCreateCategory()
+                    } label: {
+                        Label("Create Category", systemImage: "plus")
+                    }
+                    .disabled(!journal.splits.isEmpty)
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .accessibilityLabel("More create actions")
+            }
+        }
 
         .onAppear {
             // Initialize state variables from the journal object when the view appears
@@ -283,6 +331,77 @@ struct EnterFormView: View {
         }
         .onDisappear {
             focusState = nil
+        }
+        .sheet(isPresented: $showingCreateAccount) {
+            NavigationView {
+                RepositoryCreateView(
+                    isPresented: $showingCreateAccount,
+                    features: AccountListView.features,
+                    data: createAccountData,
+                    newData: $newAccountData,
+                    formView: { focus, data, edit in
+                        AccountFormView(focus: focus, data: data, edit: edit)
+                    }
+                )
+                .navigationBarTitle("Create Account", displayMode: .inline)
+            }
+            .onDisappear {
+                guard let created = newAccountData else { return }
+                Task { @MainActor in
+                    await vm.reloadAccount(pref, nil as AccountData?, created)
+                    switch createAccountTarget {
+                    case .account:
+                        journal.accountId = created.id
+                    case .toAccount:
+                        journal.toAccountId = created.id
+                    }
+                    newAccountData = nil
+                }
+            }
+        }
+        .sheet(isPresented: $showingCreatePayee) {
+            NavigationView {
+                RepositoryCreateView(
+                    isPresented: $showingCreatePayee,
+                    features: PayeeListView.features,
+                    data: createPayeeData,
+                    newData: $newPayeeData,
+                    formView: { focus, data, edit in
+                        PayeeFormView(focus: focus, data: data, edit: edit)
+                    }
+                )
+                .navigationBarTitle("Create Payee", displayMode: .inline)
+            }
+            .onDisappear {
+                guard let created = newPayeeData else { return }
+                Task { @MainActor in
+                    await vm.reloadPayee(pref, nil as PayeeData?, created)
+                    journal.payeeId = created.id
+                    newPayeeData = nil
+                }
+            }
+        }
+        .sheet(isPresented: $showingCreateCategory) {
+            NavigationView {
+                RepositoryCreateView(
+                    isPresented: $showingCreateCategory,
+                    features: CategoryListView.features,
+                    data: createCategoryData,
+                    newData: $newCategoryData,
+                    formView: { focus, data, edit in
+                        CategoryFormView(focus: focus, data: data, edit: edit)
+                    }
+                )
+                .navigationBarTitle("Create Category", displayMode: .inline)
+            }
+            .onDisappear {
+                guard let created = newCategoryData else { return }
+                Task { @MainActor in
+                    await vm.reloadCategory(pref, nil as CategoryData?, created)
+                    journal.categId = created.id
+                    newCategoryData = nil
+                }
+            }
         }
         .sheet(isPresented: $showingSplitEditor) {
             SplitEditView(
@@ -304,6 +423,30 @@ struct EnterFormView: View {
                 } : nil
             )
         }
+    }
+
+    private func prepareCreateAccount() {
+        createAccountTarget = .account
+        var data = AccountListView.initData
+        data.currencyId = vm.accountList.data.readyValue?[journal.accountId]?.currencyId
+            ?? vm.accountList.order.readyValue?.first.flatMap { vm.accountList.data.readyValue?[$0]?.currencyId }
+            ?? .void
+        createAccountData = data
+        showingCreateAccount = true
+    }
+
+    private func prepareCreatePayee() {
+        var data = PayeeListView.initData
+        if !journal.categId.isVoid {
+            data.categoryId = journal.categId
+        }
+        createPayeeData = data
+        showingCreatePayee = true
+    }
+
+    private func prepareCreateCategory() {
+        createCategoryData = CategoryListView.initData
+        showingCreateCategory = true
     }
 }
 

--- a/MMEX/View/Enter/EnterView.swift
+++ b/MMEX/View/Enter/EnterView.swift
@@ -44,6 +44,9 @@ struct EnterView: View {
                 }
                 .disabled(!newJournal.isValid)
             }
+            ToolbarItem(placement: .confirmationAction) {
+                KeyboardFocus(focus: $focus)
+            }
         }
         .task {
             await load()

--- a/MMEX/View/Enter/EnterView.swift
+++ b/MMEX/View/Enter/EnterView.swift
@@ -44,9 +44,6 @@ struct EnterView: View {
                 }
                 .disabled(!newJournal.isValid)
             }
-            ToolbarItem(placement: .confirmationAction) {
-                KeyboardFocus(focus: $focus)
-            }
         }
         .task {
             await load()


### PR DESCRIPTION
This pull request introduces a streamlined workflow for creating new accounts, payees, and categories directly from the transaction entry form. The main changes add a toolbar menu for these actions, along with corresponding modal sheets for data entry and logic to update the transaction with newly created entities. There are also minor updates to localization files to support the new UI elements.

**New create-entity workflow in transaction entry:**

* Added a trailing navigation bar menu in `EnterFormView` with options to "Create Account", "Create Payee", and "Create Category", each opening a modal sheet for creation.
* Implemented modal sheets for each entity type (`Account`, `Payee`, `Category`) using `RepositoryCreateView`, and logic to update the transaction form with the newly created entity upon completion.
* Added helper methods (`prepareCreateAccount`, `prepareCreatePayee`, `prepareCreateCategory`) to initialize entity creation with relevant context from the transaction.
* Introduced local state for managing the creation process and storing new entity data in `EnterFormView`.
* Added an `AccountSelectionTarget` enum to handle post-creation selection logic for accounts.

**Localization support:**

* Added new keys in `Localizable.xcstrings` for "Create Account", "Create Payee", "Create Category", and "More create actions" to support the new UI. [[1]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R3174-R3179) [[2]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R3238-R3240) [[3]](diffhunk://#diff-597a7720f9d1a2489283d0f9745e02b1d0546be2126c14340d3159007b0ef023R8298-R8300)

**UI adjustments:**

* Removed the keyboard focus toolbar item from `EnterView`, as the new workflow makes it redundant.