### PR TITLE
bugfix: limit change to ipad layout and revert change to EnterView

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -1539,7 +1539,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1562,7 +1562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",
@@ -1587,7 +1587,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
@@ -1606,7 +1606,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",

--- a/MMEX/App/ContentView.swift
+++ b/MMEX/App/ContentView.swift
@@ -114,12 +114,12 @@ struct ContentView: View {
                     isAttachDocumentPickerPresented: $isAttachDocumentPickerPresented,
                     isSampleDocument: $isSampleDocument
                 )
+                .id(detailTabSelection)
             }
             .sheet(isPresented: $isPresentingTransactionAddView) {
                 NavigationStack {
                     EnterView(
-                        selectedTab: $selectedTab,
-                        dismissSelection: iPadReturnTab
+                        selectedTab: iPadEnterSelectionBinding
                     )
                 }
             }
@@ -225,10 +225,7 @@ struct ContentView: View {
 
     private func enterTab() -> some View {
         NavigationView {
-            EnterView(
-                selectedTab: $selectedTab,
-                dismissSelection: Preference.selectedTab
-            )
+            EnterView(selectedTab: $selectedTab)
                 .navigationBarTitle("Enter", displayMode: .inline)
         }
         .tabItem {
@@ -352,9 +349,26 @@ struct SidebarView: View {
 }
 
 extension ContentView {
+    private var detailTabSelection: Int {
+        selectedTab == 2 ? iPadReturnTab : selectedTab
+    }
+
+    private var iPadEnterSelectionBinding: Binding<Int> {
+        Binding(
+            get: { selectedTab },
+            set: { newValue in
+                if newValue == Preference.selectedTab {
+                    selectedTab = iPadReturnTab
+                } else {
+                    selectedTab = newValue
+                }
+            }
+        )
+    }
+
     private var detailTabBinding: Binding<Int> {
         Binding(
-            get: { selectedTab == 2 ? iPadReturnTab : selectedTab },
+            get: { detailTabSelection },
             set: { selectedTab = $0 }
         )
     }
@@ -382,10 +396,7 @@ struct TabContentView: View {
                 InsightsView()
                     .navigationBarTitle("Insights", displayMode: .inline)
             case 2:
-                EnterView(
-                    selectedTab: $selectedTab,
-                    dismissSelection: Preference.selectedTab
-                )
+                EnterView(selectedTab: $selectedTab)
                     .navigationBarTitle("Enter", displayMode: .inline)
             case 3:
                 ManageView(

--- a/MMEX/View/Enter/EnterView.swift
+++ b/MMEX/View/Enter/EnterView.swift
@@ -13,7 +13,6 @@ struct EnterView: View {
     @EnvironmentObject var vm: ViewModel
     @EnvironmentObject var context: AppContext
     @Binding var selectedTab: Int
-    let dismissSelection: Int?
 
     @State private var focus = false
     @State var newJournal: JournalData = .newTransaction()
@@ -28,9 +27,7 @@ struct EnterView: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") {
                     dismiss()
-                    if let dismissSelection {
-                        selectedTab = dismissSelection
-                    }
+                    selectedTab = Preference.selectedTab
                     resetJournal()
                 }
             }
@@ -38,9 +35,7 @@ struct EnterView: View {
                 Button("Done") {
                     if (vm.saveJournal(&newJournal)) {
                         dismiss()
-                        if let dismissSelection {
-                            selectedTab = dismissSelection
-                        }
+                        selectedTab = Preference.selectedTab
                         resetJournal()
                     } else {
                         // TODO
@@ -112,8 +107,7 @@ struct EnterView: View {
 #Preview {
     MMEXPreview.tab("Enter") { pref, vm in
         EnterView(
-            selectedTab: .constant(0),
-            dismissSelection: Preference.selectedTab
+            selectedTab: .constant(0)
         )
     }
 }
@@ -128,7 +122,6 @@ extension MMEXPreview {
         MMEXPreview.tab("Enter") { pref, vm in
             EnterView(
                 selectedTab: .constant(0),
-                dismissSelection: Preference.selectedTab,
                 newJournal: JournalData(data)
             )
         }


### PR DESCRIPTION
This pull request updates the app and project version numbers and refactors how tab selection and dismissal are handled in the `EnterView` and related navigation flows. The main focus is on simplifying the tab management logic and ensuring consistent behavior when dismissing or completing entries.

**Project Version Updates:**

* [`MMEX.xcodeproj/project.pbxproj`](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1542-R1542): Bumped `CURRENT_PROJECT_VERSION` to 44 and `MARKETING_VERSION` to 0.2.5 to reflect the new release. [[1]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1542-R1542) [[2]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1565-R1565) [[3]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1590-R1590) [[4]](diffhunk://#diff-9f16f10197ed57b8321f6a20db933eca2600094230162a7e4a5cbbd0920e2360L1609-R1609)

**Tab Selection and Dismissal Refactor:**

* `MMEX/App/ContentView.swift`, `MMEX/View/Enter/EnterView.swift`: Removed the `dismissSelection` parameter from `EnterView` and replaced its usage with `Preference.selectedTab` for consistent tab switching on cancel/done actions. [[1]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31L228-R228) [[2]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31L385-R399) [[3]](diffhunk://#diff-c45cc8f4ba1156577a7a80b1e05fd01d733eeb6823e870ea5b2baf72b2b1e5feL16) [[4]](diffhunk://#diff-c45cc8f4ba1156577a7a80b1e05fd01d733eeb6823e870ea5b2baf72b2b1e5feL31-R38) [[5]](diffhunk://#diff-c45cc8f4ba1156577a7a80b1e05fd01d733eeb6823e870ea5b2baf72b2b1e5feL115-R110) [[6]](diffhunk://#diff-c45cc8f4ba1156577a7a80b1e05fd01d733eeb6823e870ea5b2baf72b2b1e5feL131)
* [`MMEX/App/ContentView.swift`](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31R352-R371): Introduced new computed properties (`detailTabSelection`, `iPadEnterSelectionBinding`) to centralize and clarify tab selection logic, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31R352-R371) [[2]](diffhunk://#diff-de7d8a2e15e7a996c4abde211a378ee2d53d15a3cfa31df652caf977288a4d31R117-R122)

These changes streamline navigation and tab management, making the codebase easier to maintain and less error-prone.