### PR TITLE
support blind friendly financial colors

### DIFF
--- a/MMEX.xcodeproj/project.pbxproj
+++ b/MMEX.xcodeproj/project.pbxproj
@@ -1539,7 +1539,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1562,7 +1562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = 0.2.6;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",
@@ -1587,7 +1587,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_ASSET_PATHS = "\"MMEX/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
@@ -1606,7 +1606,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = 0.2.6;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
 					"-DNDEBUG",

--- a/MMEX/Preference/Theme.swift
+++ b/MMEX/Preference/Theme.swift
@@ -8,8 +8,29 @@
 import Foundation
 import SwiftUI
 
+enum FinancialColorScheme: String, ChoiceProtocol {
+    case classic = "Classic"
+    case colorBlindFriendly = "Blue/Orange"
+    static let defaultValue = Self.classic
+
+    var incomeColor: Color {
+        switch self {
+        case .classic: .green
+        case .colorBlindFriendly: .blue
+        }
+    }
+
+    var expenseColor: Color {
+        switch self {
+        case .classic: .red
+        case .colorBlindFriendly: .orange
+        }
+    }
+}
+
 struct Theme {
     @StoredPreference var appearance: Appearance = .defaultValue
+    @StoredPreference var financialColorScheme: FinancialColorScheme = .defaultValue
     @StoredPreference var numericKeypad: BoolChoice = .boolTrue
     @StoredPreference var categoryDelimiter: String = ":"
     @StoredPreferenceDictionary(key: "CategorySymbols") var symbols: [String: String]
@@ -23,6 +44,7 @@ struct Theme {
 extension Theme {
     init(prefix: String?) {
         self.$appearance        = prefix?.appending("appearance")
+        self.$financialColorScheme = prefix?.appending("financialColorScheme")
         self.$numericKeypad     = prefix?.appending("numericKeypad")
         self.$categoryDelimiter = prefix?.appending("categoryDelimiter")
 
@@ -34,6 +56,22 @@ extension Theme {
 }
 
 extension Theme {
+    var incomeColor: Color {
+        financialColorScheme.incomeColor
+    }
+
+    var expenseColor: Color {
+        financialColorScheme.expenseColor
+    }
+
+    func amountColor(for transactionType: TransactionType) -> Color {
+        transactionType == .deposit ? incomeColor : expenseColor
+    }
+
+    func changeColor(for amount: Double) -> Color {
+        amount >= 0 ? incomeColor : expenseColor
+    }
+
     var decimalPad: UIKeyboardType {
         switch numericKeypad {
         case .boolTrue: .decimalPad

--- a/MMEX/Resources/Localizable.xcstrings
+++ b/MMEX/Resources/Localizable.xcstrings
@@ -5978,6 +5978,9 @@
         }
       }
     },
+    "Financial Colors" : {
+
+    },
     "Format" : {
       "localizations" : {
         "cs" : {

--- a/MMEX/View/Insights/IncomeExpenseView.swift
+++ b/MMEX/View/Insights/IncomeExpenseView.swift
@@ -11,6 +11,7 @@ import Charts
 struct IncomeExpenseView: View {
     @Binding var stats: [TransactionData]
     @State private var selectedDate: String?
+    @EnvironmentObject var pref: Preference
     
     var body: some View {
         Chart {
@@ -21,7 +22,7 @@ struct IncomeExpenseView: View {
                 )
                 .foregroundStyle(
                     LinearGradient(
-                        gradient: Gradient(colors: [.green.opacity(0.4), .green.opacity(0.9)]),
+                        gradient: Gradient(colors: [pref.theme.incomeColor.opacity(0.4), pref.theme.incomeColor.opacity(0.9)]),
                         startPoint: .top,
                         endPoint: .bottom
                     )
@@ -35,7 +36,7 @@ struct IncomeExpenseView: View {
                 )
                 .foregroundStyle(
                     LinearGradient(
-                        gradient: Gradient(colors: [.red.opacity(0.4), .red.opacity(0.9)]),
+                        gradient: Gradient(colors: [pref.theme.expenseColor.opacity(0.4), pref.theme.expenseColor.opacity(0.9)]),
                         startPoint: .bottom,
                         endPoint: .top
                     )

--- a/MMEX/View/Journal/JournalView.swift
+++ b/MMEX/View/Journal/JournalView.swift
@@ -177,7 +177,7 @@ struct JournalView: View {
                         Text(txn.transAmount.formatted(by: currencyInfo.formatter))
                         .frame(alignment: .trailing) // Ensure it's aligned to the right
                         .font(.system(size: 16, weight: .bold))
-                        .foregroundColor(txn.transCode == TransactionType.deposit ? .green : .red) // Positive/negative amount color
+                        .foregroundColor(pref.theme.amountColor(for: txn.transCode))
                         // amount in base currency
                         if let baseCurrencyId = vm.infotableList.baseCurrencyId.readyValue,
                            baseCurrencyId != currencyId
@@ -187,7 +187,7 @@ struct JournalView: View {
                             )
                             .frame(alignment: .trailing) // Ensure it's aligned to the right
                             .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(txn.transCode == TransactionType.deposit ? .green : .red) // Positive/negative amount color
+                            .foregroundColor(pref.theme.amountColor(for: txn.transCode))
                         }
                     }
                 } else {
@@ -195,7 +195,7 @@ struct JournalView: View {
                     Text(String(format: "%.2f", txn.transAmount))
                         .frame(alignment: .trailing) // Ensure it's aligned to the right
                         .font(.system(size: 16, weight: .bold))
-                        .foregroundColor(txn.transCode == TransactionType.deposit ? .green : .red) // Positive/negative amount color
+                        .foregroundColor(pref.theme.amountColor(for: txn.transCode))
                 }
             }
         }

--- a/MMEX/View/Manage/Transaction/TransactionListView.swift
+++ b/MMEX/View/Manage/Transaction/TransactionListView.swift
@@ -50,7 +50,7 @@ struct TransactionListView: View {
                         Text(String(format: "%.2f", journal.transAmount))
                             .frame(alignment: .trailing)
                             .font(.system(size: 16, weight: .bold))
-                            .foregroundColor(journal.transAmount >= 0 ? .green : .red)
+                            .foregroundColor(pref.theme.changeColor(for: journal.transAmount))
                     }
                 }
             }

--- a/MMEX/View/Overview/FinancialSummaryCard.swift
+++ b/MMEX/View/Overview/FinancialSummaryCard.swift
@@ -18,6 +18,7 @@ struct FinancialSummaryCard: View {
     @Binding var selectedFilter: TransactionType?
     let formatter: CurrencyFormatter?
     
+    @EnvironmentObject var pref: Preference
     @EnvironmentObject var vm: ViewModel
     
     var body: some View {
@@ -84,7 +85,7 @@ struct FinancialSummaryCard: View {
                 Text(netWorth.formatted(by: formatter))
                     .font(.largeTitle)
                     .fontWeight(.bold)
-                    .foregroundColor(netWorth >= 0 ? .primary : .red)
+                    .foregroundColor(netWorth >= 0 ? .primary : pref.theme.expenseColor)
             }
             
             Spacer()
@@ -98,7 +99,7 @@ struct FinancialSummaryCard: View {
                             .font(.caption)
                             .fontWeight(.medium)
                     }
-                    .foregroundColor(netWorthChange >= 0 ? .green : .red)
+                    .foregroundColor(pref.theme.changeColor(for: netWorthChange))
                     
                     if previousNetWorth != 0 {
                         Text("vs \(previousNetWorth.formatted(by: formatter))")
@@ -116,7 +117,7 @@ struct FinancialSummaryCard: View {
                 let isPositive = txn.transCode == .deposit
                 let height = CGFloat(min(abs(txn.transAmount) / 100 + 2, 20))
                 Rectangle()
-                    .fill(isPositive ? Color.green : Color.red)
+                    .fill(isPositive ? pref.theme.incomeColor : pref.theme.expenseColor)
                     .frame(width: 4, height: height)
             }
         }
@@ -136,13 +137,15 @@ struct MetricCard: View {
     let isSelected: Bool
     let formatter: CurrencyFormatter?
     let onTap: () -> Void
+
+    @EnvironmentObject var pref: Preference
     
     private var amountColor: Color {
-        filterType == .deposit ? .green : .red
+        filterType == .deposit ? pref.theme.incomeColor : pref.theme.expenseColor
     }
     
     private var changeColor: Color {
-        change >= 0 ? .green : .red
+        pref.theme.changeColor(for: change)
     }
     
     var body: some View {

--- a/MMEX/View/Overview/RecentTransactionsView.swift
+++ b/MMEX/View/Overview/RecentTransactionsView.swift
@@ -147,7 +147,7 @@ struct TransactionRow: View {
             Text(journal.transAmount.formatted(by: formatter))
                 .frame(alignment: .trailing)
                 .font(.system(size: 16, weight: .bold))
-                .foregroundColor(journal.transCode == .deposit ? .green : .red)
+                .foregroundColor(pref.theme.amountColor(for: journal.transCode))
         }
         .padding(.vertical, 2)
     }

--- a/MMEX/View/Overview/ScheduledOverviewView.swift
+++ b/MMEX/View/Overview/ScheduledOverviewView.swift
@@ -114,7 +114,7 @@ struct ScheduledOverviewView: View {
     
     private var sections: [(title: String, color: Color, items: [ScheduledOverviewItem])] {
         [
-            ("Overdue", .red, viewModel.overdue),
+            ("Overdue", pref.theme.expenseColor, viewModel.overdue),
             ("Due Today", .orange, viewModel.dueToday),
             ("Due Soon", .blue, viewModel.dueSoon),
             ("Upcoming", .secondary, viewModel.upcoming)
@@ -162,13 +162,13 @@ struct ScheduledOverviewView: View {
                     Text(item.scheduled.transAmount.formatted(by: formatter))
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(item.status == .overdue ? .red : .primary)
+                        .foregroundColor(item.status == .overdue ? pref.theme.expenseColor : .primary)
                 }
                 
                 HStack {
                     Text(item.daysText)
                         .font(.caption)
-                        .foregroundColor(item.status == .overdue ? .red : .secondary)
+                        .foregroundColor(item.status == .overdue ? pref.theme.expenseColor : .secondary)
                     
                     Spacer()
                     
@@ -188,7 +188,7 @@ struct ScheduledOverviewView: View {
                             .font(.caption)
                             .buttonStyle(.borderedProminent)
                             .controlSize(.mini)
-                            .tint(.green)
+                            .tint(pref.theme.incomeColor)
                         }
                     } else {
                         Text("One-time")

--- a/MMEX/View/Settings/ThemeView.swift
+++ b/MMEX/View/Settings/ThemeView.swift
@@ -49,6 +49,16 @@ struct ThemeView: View {
                 }
 
                 HStack {
+                    Text("Financial Colors")
+                    Spacer()
+                    Picker("", selection: $pref.theme.financialColorScheme) {
+                        ForEach(FinancialColorScheme.allCases) { choice in
+                            Text(choice.rawValue).tag(choice)
+                        }
+                    }
+                }
+
+                HStack {
                     Text("Date Format")
                     Spacer()
                     Text("\(dateFormat)")


### PR DESCRIPTION
This pull request introduces a user-selectable color scheme for financial indicators (income and expense) throughout the app, improving accessibility and user customization. The main changes involve adding a new `FinancialColorScheme` preference, updating UI components to use theme-based colors, and providing a settings UI for users to choose their preferred color scheme.

**Themed Color Support and Preference:**
- Added the `FinancialColorScheme` enum and related properties/methods to the `Theme` struct, allowing users to select between "Classic" (green/red) and "Blue/Orange" color schemes for income and expense indicators. [[1]](diffhunk://#diff-902b2be4c671e02a71db1277444f4f38799ffec60d3528a32a4bd7a0445406f6R11-R33) [[2]](diffhunk://#diff-902b2be4c671e02a71db1277444f4f38799ffec60d3528a32a4bd7a0445406f6R47) [[3]](diffhunk://#diff-902b2be4c671e02a71db1277444f4f38799ffec60d3528a32a4bd7a0445406f6R59-R74)
- Updated the settings UI in `ThemeView` to include a picker for the new "Financial Colors" preference.

**UI Updates to Use Theme Colors:**
- Replaced hardcoded `.green` and `.red` colors in transaction, chart, summary, and scheduled views with theme-based colors accessed via the new `Theme` methods. This ensures all financial indicators reflect the user's selected color scheme. [[1]](diffhunk://#diff-2875b436a768d4ff6e96ecdddd5ce73cbe8172d6b17b574a9c4201a4cc8813d7L24-R25) [[2]](diffhunk://#diff-2875b436a768d4ff6e96ecdddd5ce73cbe8172d6b17b574a9c4201a4cc8813d7L38-R39) [[3]](diffhunk://#diff-2f64267a0d685976c202a76ace51c75cda3f8a843cf31a3abf7e2ae8d667700eL180-R180) [[4]](diffhunk://#diff-2f64267a0d685976c202a76ace51c75cda3f8a843cf31a3abf7e2ae8d667700eL190-R198) [[5]](diffhunk://#diff-e2d127570a7758eb4c147a3b46efbadb11f9eca2c983ee4b2361d5a04d192969L53-R53) [[6]](diffhunk://#diff-36807f68642668416ea3f199f8faf24d3c5081c10f071e8c043e49c851ae1a38L87-R88) [[7]](diffhunk://#diff-36807f68642668416ea3f199f8faf24d3c5081c10f071e8c043e49c851ae1a38L101-R102) [[8]](diffhunk://#diff-36807f68642668416ea3f199f8faf24d3c5081c10f071e8c043e49c851ae1a38L119-R120) [[9]](diffhunk://#diff-36807f68642668416ea3f199f8faf24d3c5081c10f071e8c043e49c851ae1a38R141-R148) [[10]](diffhunk://#diff-1c8dcd0839b38d3563cdbeae4bec20f67043d9b6e0d1a034b1837216c1d28fc8L150-R150) [[11]](diffhunk://#diff-33bf0f8ff7721c6753a3450d199a2309819fae83075d3619cc284c879ebd993aL117-R117) [[12]](diffhunk://#diff-33bf0f8ff7721c6753a3450d199a2309819fae83075d3619cc284c879ebd993aL165-R171) [[13]](diffhunk://#diff-33bf0f8ff7721c6753a3450d199a2309819fae83075d3619cc284c879ebd993aL191-R191)

**Localization:**
- Added a localization key for "Financial Colors" to support internationalization of the new settings option.